### PR TITLE
Make `run_cypher` argument `params` default to `None`

### DIFF
--- a/graphdatascience/graph_data_science.py
+++ b/graphdatascience/graph_data_science.py
@@ -93,7 +93,7 @@ class GraphDataScience(DirectEndpoints, UncallableNamespace):
     def database(self) -> Optional[str]:
         return self._query_runner.database()
 
-    def run_cypher(self, query: str, params: Dict[str, Any] = {}) -> DataFrame:
+    def run_cypher(self, query: str, params: Optional[Dict[str, Any]] = None) -> DataFrame:
         return self._query_runner.run_query(query, params)
 
     def driver_config(self) -> Dict[str, Any]:

--- a/graphdatascience/query_runner/neo4j_query_runner.py
+++ b/graphdatascience/query_runner/neo4j_query_runner.py
@@ -21,7 +21,7 @@ class Neo4jQueryRunner(QueryRunner):
         self._auto_close = auto_close
         self._db = db
 
-    def run_query(self, query: str, params: Optional[Dict[str, str]] = None) -> DataFrame:
+    def run_query(self, query: str, params: Optional[Dict[str, Any]] = None) -> DataFrame:
         if params is None:
             params = {}
 


### PR DESCRIPTION
Since the previous default, `{}`, is only initiated at method definition
and not for every call of the method. This might prevent future bugs, in
the case where the query runner populates the default params with
something every call.