### PR TITLE
Remove Python 3.10 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Topic :: Database",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,5 @@
 [tox]
-envlist =
-	py{37,38,39}-pyarrow{4,5,6,7,8}-{standard,encrypted},
-	py310-pyarrow{7,8}-{standard,encrypted}
+envlist = py{37,38,39}-pyarrow{4,5,6,7,8}-{standard,encrypted}
 
 [testenv]
 deps =


### PR DESCRIPTION
We can not support Python 3.10 since the Neo4j Bolt driver does not support 3.10 and we heavily rely on it. The problem surfaced when using encrypted connections to the server where we ran into https://peps.python.org/pep-0644/
