### PR TITLE
Merge `doc` and `standard` tox commands

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,9 @@ passenv =
 	NEO4J_USER
 	NEO4J_PASSWORD
 	NEO4J_DB
-whitelist_externals = ruby
+whitelist_externals =
+	ruby
+	bash
 deps =
 	pytest
 	neo4j4: neo4j >= 4.4.2, < 5.0
@@ -23,8 +25,7 @@ deps =
 	pyarrow8: pyarrow >= 8.0, < 9.0
 	pyarrow9: pyarrow >= 9.0, < 10.0
 commands =
-	standard: pytest graphdatascience/tests --include-enterprise --include-model-store-location -Werror
+	standard: bash -ec 'pytest graphdatascience/tests/unit --include-enterprise --include-model-store-location -Werror && ruby ./doc/tests/test_docs.rb python3'
 	encrypted: pytest graphdatascience/tests --encrypted-only -Werror
 	aura: pytest graphdatascience/tests --include-enterprise --target-aura -Werror
-	doc: ruby ./doc/tests/test_docs.rb python3
 


### PR DESCRIPTION
To save disk space in CI, since now the doc tests and the implementation tests will share tox environments.

Thank you for your contribution to the Graph Data Science Client project.

<!-- Please include a summary of the change, such as, which issue was fixed or feature was added. 
If relevant, link to the corresponding issue.
Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Before submitting this PR, please read [Contributing to the Neo4j Ecosystem](https://github.com/neo4j/graph-data-science-client/blob/main/CONTRIBUTING.md). 

Make sure:
- [x] You signed the [Neo4j CLA](https://neo4j.com/developer/cla/#sign-cla) (Contributor License Agreement) so that we are allowed to ship your code in our library
- [x] Your contribution is covered by tests

