### PR TITLE
Allow specifying targeted db on gds object construction

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 This method converts the topology result to a map from relationship types to matrices describing the topology of the type.
 * Added a new optional string parameter `database` to `GraphDataScience.run_cypher` for overriding which database to target.
 * Added new method `gds.graph.load_cora` to load the CORA dataset into GDS.
+* Added a new optional string parameter `database` to the `GraphDataScience` constructor for specifying the targeted database.
 
 
 ## Bug fixes

--- a/doc/modules/ROOT/pages/getting-started.adoc
+++ b/doc/modules/ROOT/pages/getting-started.adoc
@@ -40,13 +40,6 @@ assert gds.version()
 
 Alternatively, for use cases where direct access and control of the Neo4j driver is required, one can use the method `GraphDataScience.from_neo4j_driver` for instantiating the gds object.
 
-If we don't want to use the default database of our DBMS, we can specify which one to use:
-
-[source,python,role=no-test]
-----
-gds.set_database("my-db")
-----
-
 To check if the GDS server library we're running against is licensed we can make the following call:
 
 [source,python]
@@ -61,6 +54,23 @@ Therefore most methods, such as `pageRank`, will not appear when calling `dir(gd
 Similarly, IDEs and language servers will not be able to detect these automatically inferred methods, meaning that the auto-completion support they provide will be limited.
 Rest assured however that despite the lack of this type of discoverability the inferred methods, such as `gds.pageRank.stream`, will still be called correctly.
 ====
+
+
+=== Specifying targeted database
+
+If we don't want to use the default database of our DBMS we can provide the `GraphDataScience` constructor with the keyword parameter `database`:
+
+[source,python,role=no-test]
+----
+gds = GraphDataScience(NEO4J_URI, auth=(NEO4J_USER, NEO4J_PASSWORD), database="my-db")
+----
+
+Or we could change the database we are targeting later:
+
+[source,python,role=no-test]
+----
+gds.set_database("my-db")
+----
 
 
 === AuraDS

--- a/graphdatascience/graph_data_science.py
+++ b/graphdatascience/graph_data_science.py
@@ -25,6 +25,7 @@ class GraphDataScience(DirectEndpoints, UncallableNamespace):
         endpoint: Union[str, Driver, QueryRunner],
         auth: Optional[Tuple[str, str]] = None,
         aura_ds: bool = False,
+        database: Optional[str] = None,
         arrow: bool = True,
         arrow_disable_server_verification: bool = True,
         arrow_tls_root_certs: Optional[bytes] = None,
@@ -116,6 +117,9 @@ class GraphDataScience(DirectEndpoints, UncallableNamespace):
                     "registered for this database instance." not in str(e)
                 ):
                     warnings.warn(f"Could not initialize GDS Flight Server client: {e}")
+
+        if database:
+            self._query_runner.set_database(database)
 
         super().__init__(self._query_runner, "gds", self._server_version)
 

--- a/graphdatascience/tests/integration/test_database_ops.py
+++ b/graphdatascience/tests/integration/test_database_ops.py
@@ -49,6 +49,27 @@ def test_run_query_with_db(runner: Neo4jQueryRunner) -> None:
     runner.run_query("DROP DATABASE $dbName", {"dbName": MY_DB_NAME})
 
 
+@pytest.mark.skip_on_aura
+def test_initialize_with_db(runner: Neo4jQueryRunner) -> None:
+    runner.run_query("CREATE (a: Node)")
+
+    default_db_count = runner.run_query("MATCH (n: Node) RETURN COUNT(n) AS c")["c"][0]
+    assert default_db_count == 1
+
+    MY_DB_NAME = "my-db"
+    runner.run_query("CREATE DATABASE $dbName", {"dbName": MY_DB_NAME})
+
+    gds_with_specified_db = GraphDataScience(URI, AUTH, database=MY_DB_NAME)
+
+    specified_db_count = gds_with_specified_db.run_cypher("MATCH (n: Node) RETURN COUNT(n) AS c", database=MY_DB_NAME)[
+        "c"
+    ][0]
+    assert specified_db_count == 0
+
+    runner.run_query("MATCH (n) DETACH DELETE n")
+    runner.run_query("DROP DATABASE $dbName", {"dbName": MY_DB_NAME})
+
+
 def test_from_neo4j_driver(neo4j_driver: Driver) -> None:
     gds = GraphDataScience.from_neo4j_driver(neo4j_driver)
     assert len(gds.list()) > 10


### PR DESCRIPTION
This implements the feature request from #190 

Thank you for your contribution to the Graph Data Science Client project.

<!-- Please include a summary of the change, such as, which issue was fixed or feature was added. 
If relevant, link to the corresponding issue.
Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Before submitting this PR, please read [Contributing to the Neo4j Ecosystem](https://github.com/neo4j/graph-data-science-client/blob/main/CONTRIBUTING.md). 

Make sure:
- [ ] You signed the [Neo4j CLA](https://neo4j.com/developer/cla/#sign-cla) (Contributor License Agreement) so that we are allowed to ship your code in our library
- [ ] Your contribution is covered by tests

