### PR TITLE
Support setting and list defaults

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,6 @@
 * For GDS admin users, `gds.graph.get` is now able to resolve graph names into `Graph` objects of other users graph projections.
 * Add support for `gds.alpha.triangles`.
 * Support calling `gds.alpha.userLog` to access hints and warnings for the recently run operations.
-
+* Add support for `gds.alpha.config.defaults.set` and `gds.alpha.config.defaults.list`.
 
 ## Other changes

--- a/graphdatascience/indirect_endpoints.py
+++ b/graphdatascience/indirect_endpoints.py
@@ -5,7 +5,7 @@ from .model.model_endpoints import ModelEndpoints
 from .pipeline.pipeline_endpoints import PipelineEndpoints
 from .query_runner.query_runner import QueryRunner
 from .server_version.server_version import ServerVersion
-from .system.system_endpoints import IndirectSystemEndpoints
+from .system.system_endpoints import DefaultsAndLimitsEndPoints, IndirectSystemEndpoints
 from .topological_lp.topological_lp_endpoints import TopologicalLPEndpoints
 from .utils.util_endpoints import IndirectUtilEndpoints
 
@@ -23,6 +23,7 @@ class IndirectEndpoints(
     ModelEndpoints,
     PipelineEndpoints,
     IndirectSystemEndpoints,
+    DefaultsAndLimitsEndPoints,
     TopologicalLPEndpoints,
     IndirectUtilEndpoints,
 ):

--- a/graphdatascience/indirect_endpoints.py
+++ b/graphdatascience/indirect_endpoints.py
@@ -5,9 +5,10 @@ from .model.model_endpoints import ModelEndpoints
 from .pipeline.pipeline_endpoints import PipelineEndpoints
 from .query_runner.query_runner import QueryRunner
 from .server_version.server_version import ServerVersion
-from .system.system_endpoints import DefaultsAndLimitsEndPoints, IndirectSystemEndpoints
+from .system.system_endpoints import IndirectSystemEndpoints
 from .topological_lp.topological_lp_endpoints import TopologicalLPEndpoints
 from .utils.util_endpoints import IndirectUtilEndpoints
+from graphdatascience.system.config_endpoints import IndirectConfigEndpoints
 
 """
 This class should inherit endpoint classes that only contain endpoints that needs more of a prefix
@@ -23,7 +24,7 @@ class IndirectEndpoints(
     ModelEndpoints,
     PipelineEndpoints,
     IndirectSystemEndpoints,
-    DefaultsAndLimitsEndPoints,
+    IndirectConfigEndpoints,
     TopologicalLPEndpoints,
     IndirectUtilEndpoints,
 ):

--- a/graphdatascience/system/config_endpoints.py
+++ b/graphdatascience/system/config_endpoints.py
@@ -1,0 +1,37 @@
+from typing import Any, Dict, Optional
+
+from pandas import DataFrame
+
+from graphdatascience.caller_base import CallerBase
+
+
+class IndirectConfigEndpoints(CallerBase):
+    def set(self, key: str, value: Any, username: Optional[str] = None) -> None:
+        self._namespace += ".set"
+
+        params = {"key": key, "value": value}
+
+        # Checking for explicit None as '' is a valid user
+        if username is not None:
+            query = f"CALL {self._namespace}($key, $value, $username)"
+            params["username"] = username
+        else:
+            query = f"CALL {self._namespace}($key, $value)"
+
+        self._query_runner.run_query(query, params)
+
+    def list(self, key: Optional[str] = None, username: Optional[str] = None) -> DataFrame:
+        self._namespace += ".list"
+
+        config: Dict[str, Any] = {}
+
+        if key:
+            config["key"] = key
+        # Checking for explicit None as '' is a valid user
+        if username is not None:
+            config["username"] = username
+
+        query = f"CALL {self._namespace}($config)"
+        params = {"config": config}
+
+        return self._query_runner.run_query(query, params)

--- a/graphdatascience/system/system_endpoints.py
+++ b/graphdatascience/system/system_endpoints.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 from pandas import DataFrame, Series
 
@@ -64,3 +64,33 @@ class IndirectSystemEndpoints(CallerBase):
         query = f"CALL {self._namespace}()"
 
         return self._query_runner.run_query(query).squeeze()  # type: ignore
+
+    def set(self, key: str, value: Any, username: Optional[str] = None) -> None:
+        self._namespace += ".set"
+
+        params = {"key": key, "value": value}
+
+        # Checking for explicit None as '' is a valid user
+        if username is not None:
+            query = f"CALL {self._namespace}($key, $value, $username)"
+            params["username"] = username
+        else:
+            query = f"CALL {self._namespace}($key, $value)"
+
+        self._query_runner.run_query(query, params)
+
+    def list(self, key: Optional[str] = None, username: Optional[str] = None) -> DataFrame:
+        self._namespace += ".list"
+
+        config: Dict[str, Any] = {}
+
+        if key:
+            config["key"] = key
+        # Checking for explicit None as '' is a valid user
+        if username is not None:
+            config["username"] = username
+
+        query = f"CALL {self._namespace}($config)"
+        params = {"config": config}
+
+        return self._query_runner.run_query(query, params)

--- a/graphdatascience/system/system_endpoints.py
+++ b/graphdatascience/system/system_endpoints.py
@@ -16,55 +16,7 @@ class DebugProcRunner(CallerBase, UncallableNamespace, IllegalAttrChecker):
         return self._query_runner.run_query(query).squeeze()  # type: ignore
 
 
-class DirectSystemEndpoints(CallerBase):
-    @client_only_endpoint("gds")
-    def is_licensed(self) -> bool:
-        try:
-            license: str = self._query_runner.run_query(
-                "CALL gds.debug.sysInfo() YIELD key, value WHERE key = 'gdsEdition' RETURN value"
-            ).squeeze()
-        except Exception as e:
-            # AuraDS does not have `gds.debug.sysInfo`, but is always GDS EE.
-            if (
-                "There is no procedure with the name `gds.debug.sysInfo` "
-                "registered for this database instance." in str(e)
-            ):
-                license = "Licensed"
-            else:
-                raise e
-
-        return license == "Licensed"
-
-    @property
-    def debug(self) -> DebugProcRunner:
-        return DebugProcRunner(self._query_runner, f"{self._namespace}.debug", self._server_version)
-
-
-class IndirectSystemEndpoints(CallerBase):
-    def listProgress(self, job_id: Optional[str] = None) -> DataFrame:
-        self._namespace += ".listProgress"
-
-        if job_id:
-            query = f"CALL {self._namespace}($job_id)"
-            params = {"job_id": job_id}
-        else:
-            query = f"CALL {self._namespace}()"
-            params = {}
-
-        return self._query_runner.run_query(query, params)
-
-    def userLog(self) -> DataFrame:
-        self._namespace += ".userLog"
-        query = f"CALL {self._namespace}()"
-
-        return self._query_runner.run_query(query)
-
-    def systemMonitor(self) -> "Series[Any]":
-        self._namespace += ".systemMonitor"
-        query = f"CALL {self._namespace}()"
-
-        return self._query_runner.run_query(query).squeeze()  # type: ignore
-
+class DefaultAndLimitsProcRunner(CallerBase, UncallableNamespace, IllegalAttrChecker):
     def set(self, key: str, value: Any, username: Optional[str] = None) -> None:
         self._namespace += ".set"
 
@@ -94,3 +46,67 @@ class IndirectSystemEndpoints(CallerBase):
         params = {"config": config}
 
         return self._query_runner.run_query(query, params)
+
+
+class DefaultsAndLimitsEndPoints(CallerBase):
+    @property
+    def defaults(self) -> DefaultAndLimitsProcRunner:
+        return DefaultAndLimitsProcRunner(self._query_runner, f"{self._namespace}.defaults", self._server_version)
+
+    @property
+    def limits(self) -> DefaultAndLimitsProcRunner:
+        return DefaultAndLimitsProcRunner(self._query_runner, f"{self._namespace}.limits", self._server_version)
+
+
+class DirectSystemEndpoints(CallerBase):
+    @client_only_endpoint("gds")
+    def is_licensed(self) -> bool:
+        try:
+            license: str = self._query_runner.run_query(
+                "CALL gds.debug.sysInfo() YIELD key, value WHERE key = 'gdsEdition' RETURN value"
+            ).squeeze()
+        except Exception as e:
+            # AuraDS does not have `gds.debug.sysInfo`, but is always GDS EE.
+            if (
+                "There is no procedure with the name `gds.debug.sysInfo` "
+                "registered for this database instance." in str(e)
+            ):
+                license = "Licensed"
+            else:
+                raise e
+
+        return license == "Licensed"
+
+    @property
+    def debug(self) -> DebugProcRunner:
+        return DebugProcRunner(self._query_runner, f"{self._namespace}.debug", self._server_version)
+
+    @property
+    def config(self) -> DebugProcRunner:
+        return DebugProcRunner(self._query_runner, f"{self._namespace}.config", self._server_version)
+
+
+class IndirectSystemEndpoints(CallerBase):
+    def listProgress(self, job_id: Optional[str] = None) -> DataFrame:
+        self._namespace += ".listProgress"
+
+        if job_id:
+            query = f"CALL {self._namespace}($job_id)"
+            params = {"job_id": job_id}
+        else:
+            query = f"CALL {self._namespace}()"
+            params = {}
+
+        return self._query_runner.run_query(query, params)
+
+    def userLog(self) -> DataFrame:
+        self._namespace += ".userLog"
+        query = f"CALL {self._namespace}()"
+
+        return self._query_runner.run_query(query)
+
+    def systemMonitor(self) -> "Series[Any]":
+        self._namespace += ".systemMonitor"
+        query = f"CALL {self._namespace}()"
+
+        return self._query_runner.run_query(query).squeeze()  # type: ignore

--- a/graphdatascience/system/system_endpoints.py
+++ b/graphdatascience/system/system_endpoints.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from pandas import DataFrame, Series
 
@@ -14,48 +14,6 @@ class DebugProcRunner(CallerBase, UncallableNamespace, IllegalAttrChecker):
         query = f"CALL {self._namespace}()"
 
         return self._query_runner.run_query(query).squeeze()  # type: ignore
-
-
-class DefaultAndLimitsProcRunner(CallerBase, UncallableNamespace, IllegalAttrChecker):
-    def set(self, key: str, value: Any, username: Optional[str] = None) -> None:
-        self._namespace += ".set"
-
-        params = {"key": key, "value": value}
-
-        # Checking for explicit None as '' is a valid user
-        if username is not None:
-            query = f"CALL {self._namespace}($key, $value, $username)"
-            params["username"] = username
-        else:
-            query = f"CALL {self._namespace}($key, $value)"
-
-        self._query_runner.run_query(query, params)
-
-    def list(self, key: Optional[str] = None, username: Optional[str] = None) -> DataFrame:
-        self._namespace += ".list"
-
-        config: Dict[str, Any] = {}
-
-        if key:
-            config["key"] = key
-        # Checking for explicit None as '' is a valid user
-        if username is not None:
-            config["username"] = username
-
-        query = f"CALL {self._namespace}($config)"
-        params = {"config": config}
-
-        return self._query_runner.run_query(query, params)
-
-
-class DefaultsAndLimitsEndPoints(CallerBase):
-    @property
-    def defaults(self) -> DefaultAndLimitsProcRunner:
-        return DefaultAndLimitsProcRunner(self._query_runner, f"{self._namespace}.defaults", self._server_version)
-
-    @property
-    def limits(self) -> DefaultAndLimitsProcRunner:
-        return DefaultAndLimitsProcRunner(self._query_runner, f"{self._namespace}.limits", self._server_version)
 
 
 class DirectSystemEndpoints(CallerBase):

--- a/graphdatascience/tests/integration/test_coverage.py
+++ b/graphdatascience/tests/integration/test_coverage.py
@@ -59,8 +59,6 @@ IGNORED_ENDPOINTS = {
     "gds.alpha.create.cypherdb",
     "gds.alpha.backup",  # TODO: Add support for this
     "gds.alpha.restore",  # TODO: Add support for this
-    "gds.alpha.config.defaults.set",  # TODO: Add support for this
-    "gds.alpha.config.defaults.list",  # TODO: Add support for this
     "gds.alpha.config.limits.set",  # TODO: Add support for this
     "gds.alpha.config.limits.list",  # TODO: Add support for this
 }

--- a/graphdatascience/tests/integration/test_system_ops.py
+++ b/graphdatascience/tests/integration/test_system_ops.py
@@ -33,3 +33,16 @@ def test_sysInfo(gds: GraphDataScience) -> None:
 @pytest.mark.enterprise
 def test_is_licensed(gds: GraphDataScience) -> None:
     assert gds.is_licensed()
+
+
+def test_set_defaults(gds: GraphDataScience) -> None:
+    gds.alpha.config.defaults.set("option1", 2, "")
+    assert True
+
+
+def test_list_defaults(gds: GraphDataScience) -> None:
+    gds.alpha.config.defaults.set("option1", 2, "")
+    gds.alpha.config.defaults.set("option2", 2, "")
+    result = gds.alpha.config.defaults.list(username="")
+
+    assert len(result) == 2

--- a/graphdatascience/tests/unit/test_system_ops.py
+++ b/graphdatascience/tests/unit/test_system_ops.py
@@ -33,3 +33,17 @@ def test_userLog(runner: CollectingQueryRunner, gds: GraphDataScience) -> None:
 
     assert runner.last_query() == "CALL gds.alpha.userLog()"
     assert runner.last_params() == {}
+
+
+def test_set_defaults(runner: CollectingQueryRunner, gds: GraphDataScience) -> None:
+    gds.alpha.config.defaults.set("concurrency", 2, "bob")
+
+    assert runner.last_query() == "CALL gds.alpha.config.defaults.set($key, $value, $username)"
+    assert runner.last_params() == {"key": "concurrency", "value": 2, "username": "bob"}
+
+
+def test_list_defaults(runner: CollectingQueryRunner, gds: GraphDataScience) -> None:
+    gds.alpha.config.defaults.list(username="bob", key="concurrency")
+
+    assert runner.last_query() == "CALL gds.alpha.config.defaults.list($config)"
+    assert runner.last_params() == {"config": {"username": "bob", "key": "concurrency"}}


### PR DESCRIPTION
Thank you for your contribution to the Graph Data Science Client project.

<!-- Please include a summary of the change, such as, which issue was fixed or feature was added. 
If relevant, link to the corresponding issue.
Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Before submitting this PR, please read [Contributing to the Neo4j Ecosystem](https://github.com/neo4j/graph-data-science-client/blob/main/CONTRIBUTING.md). 

Make sure:
- [x] You signed the [Neo4j CLA](https://neo4j.com/developer/cla/#sign-cla) (Contributor License Agreement) so that we are allowed to ship your code in our library
- [x] Your contribution is covered by tests


At the moment, this fails as a `dict` is not hash-able for `params = {"config": config}`. 
I did not understand why it works in other places though such as for the typical algorithms yet.
