### PR TITLE
Throw better warning if construct is called multiple times

### DIFF
--- a/graphdatascience/graph/graph_proc_runner.py
+++ b/graphdatascience/graph/graph_proc_runner.py
@@ -406,7 +406,10 @@ class GraphProcRunner(CallerBase, UncallableNamespace, IllegalAttrChecker):
 
         errors = []
 
-        if self._query_runner.run_query(f"CALL gds.graph.exists('{graph_name}')")["exists"].squeeze():
+        exists = self._query_runner.run_query(f"CALL gds.graph.exists('{graph_name}') YIELD exists").squeeze()
+
+        # compare against True as (1) unit tests return None here and (2) numpys True does not work with `is True`.
+        if exists == True:  # noqa: E712
             errors.append(
                 f"Graph '{graph_name}' already exists. Please drop the existing graph or use a different name."
             )

--- a/graphdatascience/graph/graph_proc_runner.py
+++ b/graphdatascience/graph/graph_proc_runner.py
@@ -405,6 +405,12 @@ class GraphProcRunner(CallerBase, UncallableNamespace, IllegalAttrChecker):
         relationships = relationships if isinstance(relationships, List) else [relationships]
 
         errors = []
+
+        if self._query_runner.run_query(f"CALL gds.graph.exists('{graph_name}')")["exists"].squeeze():
+            errors.append(
+                f"Graph '{graph_name}' already exists. Please drop the existing graph or use a different name."
+            )
+
         for idx, node_df in enumerate(nodes):
             if "nodeId" not in node_df.columns.values:
                 errors.append(f"Node dataframe at index {idx} needs to contain a 'nodeId' column.")

--- a/graphdatascience/tests/integration/test_graph_construct.py
+++ b/graphdatascience/tests/integration/test_graph_construct.py
@@ -318,7 +318,7 @@ def warn_for_graph_alpha_construct_undirected_with_arrow(gds: GraphDataScience) 
 
 
 @pytest.mark.filterwarnings("ignore: GDS Enterprise users can use Apache Arrow")
-def test_error_on_loading_cora_twice(gds: GraphDataScience) -> None:
+def test_error_on_construct_same_graph_twice(gds: GraphDataScience) -> None:
     nodes = DataFrame({"nodeId": [0, 1]})
     relationships = DataFrame({"sourceNodeId": [0, 1], "targetNodeId": [1, 0]})
     graph_name = "g"

--- a/graphdatascience/tests/integration/test_graph_construct.py
+++ b/graphdatascience/tests/integration/test_graph_construct.py
@@ -317,6 +317,21 @@ def warn_for_graph_alpha_construct_undirected_with_arrow(gds: GraphDataScience) 
         gds.alpha.graph.construct("hello", nodes, relationships, undirected_relationship_types=["REL2"])
 
 
+@pytest.mark.filterwarnings("ignore: GDS Enterprise users can use Apache Arrow")
+def test_error_on_loading_cora_twice(gds: GraphDataScience) -> None:
+    nodes = DataFrame({"nodeId": [0, 1]})
+    relationships = DataFrame({"sourceNodeId": [0, 1], "targetNodeId": [1, 0]})
+    graph_name = "g"
+
+    G = gds.alpha.graph.construct(graph_name, nodes, relationships, concurrency=2)
+
+    try:
+        with pytest.raises(ValueError, match=f"Graph '{graph_name}' already exists."):
+            gds.alpha.graph.construct(graph_name, nodes, relationships, concurrency=2)
+    finally:
+        G.drop()
+
+
 @pytest.mark.enterprise
 @pytest.mark.compatible_with(min_inclusive=ServerVersion(2, 3, 0))
 def test_graph_construct_undirected_with_arrow(gds: GraphDataScience) -> None:


### PR DESCRIPTION
This improves the UX for beginners who accidentally call f.i. `gds.graph.load_cora` twice without cleanup.

Thank you for your contribution to the Graph Data Science Client project.

<!-- Please include a summary of the change, such as, which issue was fixed or feature was added. 
If relevant, link to the corresponding issue.
Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Before submitting this PR, please read [Contributing to the Neo4j Ecosystem](https://github.com/neo4j/graph-data-science-client/blob/main/CONTRIBUTING.md). 

Make sure:
- [x] You signed the [Neo4j CLA](https://neo4j.com/developer/cla/#sign-cla) (Contributor License Agreement) so that we are allowed to ship your code in our library
- [x] Your contribution is covered by tests

