### PR TITLE
broken link fix after flagged on semrush report

### DIFF
--- a/doc/modules/ROOT/pages/graph-object.adoc
+++ b/doc/modules/ROOT/pages/graph-object.adoc
@@ -13,7 +13,7 @@ include::ROOT:partial$/gds-object.adoc[]
 == Projecting a graph object
 
 There are several ways of projecting a graph object.
-The simplest way is to do a https://neo4j.com/docs/graph-data-science/current/graph-project/[native projection]:
+The simplest way is to do a https://neo4j.com/docs/graph-data-science/current/management-ops/projections/graph-project/[native projection]:
 
 [source,python,group=graph-project]
 ----

--- a/doc/modules/ROOT/pages/pipelines.adoc
+++ b/doc/modules/ROOT/pages/pipelines.adoc
@@ -5,7 +5,7 @@ The GDS pipelines are represented as pipeline objects.
 
 The Python method calls to _create_ the pipelines match their Cypher counterparts exactly.
 However, the rest of the pipeline functionality is deferred to methods on the pipeline objects themselves.
-Once created, the `TrainingPipeline` can be passed as arguments to methods in the Python client, such as the https://neo4j.com/docs/graph-data-science/current/pipeline-catalog/[pipeline catalog operations].
+Once created, the `TrainingPipeline` can be passed as arguments to methods in the Python client, such as the https://neo4j.com/docs/graph-data-science/current/pipeline-catalog/pipeline-catalog/[pipeline catalog operations].
 Additionally, the `TrainingPipeline` has convenience methods allowing for inspection of the pipeline represented without explicitly involving the pipeline catalog.
 
 include::ROOT:partial$/gds-object.adoc[]


### PR DESCRIPTION
Wrong link was leading to broken link page. This fix should be cherry-picked to all versions of the docs.