### PR TITLE
Adding Convenience Method to Drop Graph by Name

### DIFF
--- a/graphdatascience/graph/graph_proc_runner.py
+++ b/graphdatascience/graph/graph_proc_runner.py
@@ -108,7 +108,7 @@ class GraphProcRunner(CallerBase, UncallableNamespace, IllegalAttrChecker):
 
     def _drop_by_name(
         self,
-        name: str,
+        graph_name: str,
         failIfMissing: bool = False,
         dbName: str = "",
         username: Optional[str] = None,
@@ -116,7 +116,7 @@ class GraphProcRunner(CallerBase, UncallableNamespace, IllegalAttrChecker):
         self._namespace += ".drop"
 
         params = {
-            "graph_name": name,
+            "graph_name": graph_name,
             "fail_if_missing": failIfMissing,
             "db_name": dbName,
         }
@@ -133,14 +133,11 @@ class GraphProcRunner(CallerBase, UncallableNamespace, IllegalAttrChecker):
         return None
 
     @client_only_endpoint("gds.graph")
-    def drop_by_name(
+    def drop_if_exists(
         self,
-        name: str,
-        failIfMissing: bool = False,
-        dbName: str = "",
-        username: Optional[str] = None,
+        graph_name: str,
     ) -> Optional["Series[Any]"]:
-        return self._drop_by_name(name, failIfMissing, dbName, username)
+        return self._drop_by_name(graph_name, False)
 
     @graph_type_check
     def drop(

--- a/graphdatascience/graph/graph_proc_runner.py
+++ b/graphdatascience/graph/graph_proc_runner.py
@@ -106,10 +106,9 @@ class GraphProcRunner(CallerBase, UncallableNamespace, IllegalAttrChecker):
         self._namespace += ".sample"
         return GraphSampleRunner(self._query_runner, self._namespace, self._server_version)
 
-    @graph_type_check
-    def drop(
+    def _drop_by_name(
         self,
-        G: Graph,
+        name: str,
         failIfMissing: bool = False,
         dbName: str = "",
         username: Optional[str] = None,
@@ -117,7 +116,7 @@ class GraphProcRunner(CallerBase, UncallableNamespace, IllegalAttrChecker):
         self._namespace += ".drop"
 
         params = {
-            "graph_name": G.name(),
+            "graph_name": name,
             "fail_if_missing": failIfMissing,
             "db_name": dbName,
         }
@@ -132,6 +131,26 @@ class GraphProcRunner(CallerBase, UncallableNamespace, IllegalAttrChecker):
             return result.squeeze()  # type: ignore
 
         return None
+
+    @client_only_endpoint("gds.graph")
+    def drop_by_name(
+        self,
+        name: str,
+        failIfMissing: bool = False,
+        dbName: str = "",
+        username: Optional[str] = None,
+    ) -> Optional["Series[Any]"]:
+        return self._drop_by_name(name, failIfMissing, dbName, username)
+
+    @graph_type_check
+    def drop(
+        self,
+        G: Graph,
+        failIfMissing: bool = False,
+        dbName: str = "",
+        username: Optional[str] = None,
+    ) -> Optional["Series[Any]"]:
+        return self._drop_by_name(G.name(), failIfMissing, dbName, username)
 
     def exists(self, graph_name: str) -> "Series[Any]":
         self._namespace += ".exists"

--- a/graphdatascience/tests/integration/test_graph_ops.py
+++ b/graphdatascience/tests/integration/test_graph_ops.py
@@ -134,6 +134,16 @@ def test_graph_drop(gds: GraphDataScience) -> None:
         gds.graph.drop(G, True)
 
 
+def test_graph_drop_by_name(gds: GraphDataScience) -> None:
+    gds.graph.project(GRAPH_NAME, "*", "*")
+
+    result = gds.graph.drop_by_name(GRAPH_NAME, True)
+    assert result is not None
+    assert result["graphName"] == GRAPH_NAME
+    with pytest.raises(Exception):
+        gds.graph.drop_by_name(GRAPH_NAME, True)
+
+
 def test_graph_type_check(gds: GraphDataScience) -> None:
     G, _ = gds.graph.project(GRAPH_NAME, "*", "*")
 

--- a/graphdatascience/tests/integration/test_graph_ops.py
+++ b/graphdatascience/tests/integration/test_graph_ops.py
@@ -134,14 +134,15 @@ def test_graph_drop(gds: GraphDataScience) -> None:
         gds.graph.drop(G, True)
 
 
-def test_graph_drop_by_name(gds: GraphDataScience) -> None:
+def test_graph_drop_if_exists(gds: GraphDataScience) -> None:
     gds.graph.project(GRAPH_NAME, "*", "*")
 
-    result = gds.graph.drop_by_name(GRAPH_NAME, True)
-    assert result is not None
-    assert result["graphName"] == GRAPH_NAME
-    with pytest.raises(Exception):
-        gds.graph.drop_by_name(GRAPH_NAME, True)
+    result0 = gds.graph.drop_if_exists(GRAPH_NAME)
+    assert result0 is not None
+    assert result0["graphName"] == GRAPH_NAME
+
+    result1 = gds.graph.drop_if_exists(GRAPH_NAME)
+    assert result1 is None
 
 
 def test_graph_type_check(gds: GraphDataScience) -> None:


### PR DESCRIPTION
When using the python client, there are times when you may not have a reference object for an existing graph that you previously created in a past run (this happens for me in experimentation, but I imagine it can happen anytime you are re-running an analysis/program). If you attempt to re-project a graph with the same name you will get an error and it can be non-trivial for new users to figure out how to get a reference to the previous graph and drop it.  Ultimately to  avoid the error you can do something like
```
if gds.graph.exists(PROJ_NAME)['exists']:
    gds.graph.get(PROJ_NAME).drop()
g, _ = gds.graph.project(PROJ_NAME, ....)
```
All this PR does is add a convenience method `gds.graph.drop_by_name(PROJ_NAME,...)` so you can do 
```
gds.graph.drop_by_name(PROJ_NAME,...)
g, _ = gds.graph.project(PROJ_NAME, ....)
```
Obviously, the convenience method could also be used any other time you want to drop a graph that you do not have a reference to. 

Ideally, there would be an argument like `override=True` in the project procedure.  Looking at how the client works though I could not find an elegant way to do that and realized that a better solution, if you wanted to go that route, would probably be to add the argument on the server-side. 
