### PR TITLE
Fixing broken link leading to 404

### DIFF
--- a/doc/modules/ROOT/pages/pipelines.adoc
+++ b/doc/modules/ROOT/pages/pipelines.adoc
@@ -533,7 +533,7 @@ assert len(predictions) == H.node_count()
 == The pipeline catalog
 
 The primary way to use pipeline objects is for training models.
-Additionally, pipeline objects can be used as input to https://neo4j.com/docs/graph-data-science/current/pipeline-catalog/[GDS Pipeline Catalog operations].
+Additionally, pipeline objects can be used as input to https://neo4j.com/docs/graph-data-science/current/pipeline-catalog/pipeline-catalog/[GDS Pipeline Catalog operations].
 For instance, supposing we have a pipeline object `pipe`, we could:
 
 [source,python,group=nr-pipe]


### PR DESCRIPTION
This has been reported in SEMRush. The same fix must be applied/cherry-picked to previous branches.