### PR TITLE
Added Centrality Algorithms Example Jupyter Notebook

### DIFF
--- a/examples/centrality-algorithms.ipynb
+++ b/examples/centrality-algorithms.ipynb
@@ -469,22 +469,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/examples/centrality-algorithms.ipynb
+++ b/examples/centrality-algorithms.ipynb
@@ -24,7 +24,7 @@
     "\n",
     "Centrality algorithms are used to understand the role or influence of particular nodes in a graph. The notebook shows the application of centrality algorithms using the `graphdatascience` library on the Airline travel reachability network dataset that can be downloaded [here](https://snap.stanford.edu/data/reachability.html).\n",
     "\n",
-    "< TALK ABOUT TASKS >\n",
+    "This notebook will show how you can apply eigenvector centrality, betweenness centrality, degree centrality and closeness centrality on a graph dataset.\n",
     "\n",
     "### Setup\n",
     "\n",
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,9 +78,9 @@
     "# gds = GraphDataScience(NEO4J_URI, auth=NEO4J_AUTH)\n",
     "\n",
     "# # Replace with the actual connection URI and credentials\n",
-    "NEO4J_CONNECTION_URI = \"bolt://XXXXXXXXXXXXX\n",
+    "NEO4J_CONNECTION_URI = \"bolt://3.235.129.183:7687\"\n",
     "NEO4J_USERNAME = \"neo4j\"\n",
-    "NEO4J_PASSWORD = \"XXXXXXXXXXXXX\"\n",
+    "NEO4J_PASSWORD = \"incentives-sevenths-pear\"\n",
     "\n",
     "# Client instantiation\n",
     "gds = GraphDataScience(\n",
@@ -95,12 +95,12 @@
    "source": [
     "### Importing the dataset\n",
     "\n",
-    "We import the dataset as a pandas dataframe first. "
+    "We import the dataset as a pandas dataframe first. We deal with two files here. The file `reachability-meta.csv.gz` stores the names of the cities and their information while the file `reachability.txt.gz` stores the edges of the graph. An edge exists from city `i` to city `j` if the estimated airline travel time is less than a threshold.\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -185,14 +185,373 @@
        "4        4       Alamosa, CO     9433.0  37.468180 -105.873599"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "df = pd.read_csv('https://snap.stanford.edu/data/reachability-meta.csv.gz', compression='gzip')\n",
-    "df.head()"
+    "nodes_info_df = pd.read_csv('https://snap.stanford.edu/data/reachability-meta.csv.gz', compression='gzip')\n",
+    "nodes_info_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Origin</th>\n",
+       "      <th>Destination</th>\n",
+       "      <th>Weight</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>27</td>\n",
+       "      <td>0</td>\n",
+       "      <td>-757</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>57</td>\n",
+       "      <td>0</td>\n",
+       "      <td>-84</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>70</td>\n",
+       "      <td>0</td>\n",
+       "      <td>-1290</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>74</td>\n",
+       "      <td>0</td>\n",
+       "      <td>-465</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>86</td>\n",
+       "      <td>0</td>\n",
+       "      <td>-700</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   Origin  Destination  Weight\n",
+       "0      27            0    -757\n",
+       "1      57            0     -84\n",
+       "2      70            0   -1290\n",
+       "3      74            0    -465\n",
+       "4      86            0    -700"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "routes_df = pd.read_csv('https://snap.stanford.edu/data/reachability.txt.gz', sep=' ', skiprows=6, header=None, compression='gzip', names=['Origin', 'Destination', 'Weight'])\n",
+    "routes_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we load this data (nodes and edges) into a Graph Database and a GDS graph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Empty DataFrame\n",
+       "Columns: []\n",
+       "Index: []"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gds.run_cypher(\n",
+    "    \"UNWIND $nodes AS node CREATE (n:City {node_id: node.node_id, name: node.name, population: node.metro_pop})\",\n",
+    "    params={\"nodes\": nodes_info_df.to_dict(\"records\")},\n",
+    ")\n",
+    "\n",
+    "gds.run_cypher(\n",
+    "    \"\"\"\n",
+    "    UNWIND $rels AS rel \n",
+    "    MATCH (source:City {node_id: rel.Origin}), (target:City {node_id: rel.Destination}) \n",
+    "    CREATE (source)-[:HAS_FLIGHT_TO]->(target)\n",
+    "    \"\"\",\n",
+    "    params={\"rels\": routes_df.to_dict(\"records\")},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The projection took 214 ms\n",
+      "Graph 'airline' node count: 456\n",
+      "Graph 'airline' node labels: ['City']\n"
+     ]
+    }
+   ],
+   "source": [
+    "G, result = gds.graph.project(\"airline\", \"City\", \"HAS_FLIGHT_TO\")\n",
+    "\n",
+    "print(f\"The projection took {result['projectMillis']} ms\")\n",
+    "\n",
+    "# We can use convenience methods on `G` to check if the projection looks correct\n",
+    "print(f\"Graph '{G.name()}' node count: {G.node_count()}\")\n",
+    "print(f\"Graph '{G.name()}' node labels: {G.node_labels()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Eigenvector Centrality\n",
+    "\n",
+    "[Eigenvector centrality](https://neo4j.com/docs/graph-data-science/current/algorithms/eigenvector-centrality/) measures the importance or influence of a node based on its connections to other nodes in the network. A higher eigenvector centrality score suggests that a node is more central and influential within the network.\n",
+    "\n",
+    "For our dataset, eigenvector centrality can help identify airports that are not only well-connected themselves but also have connections to other important airports. Nodes with high eigenvector centrality are likely to be major hubs or airports with extensive connectivity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eigenvector_centrality_result = gds.eigenvector.mutate(G, maxIterations=100, mutateProperty=\"eigenvectorCentrality\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "City    [eigenvectorCentrality]\n",
+       "dtype: object"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# We can verify that the eigenvectorCentrality was mutated\n",
+    "G.node_properties()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see if our implementation converged or not and if converged, the number of iterations it took using the below code:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The number of iterations taken by Eigenvector Centrality to run is 13.\n"
+     ]
+    }
+   ],
+   "source": [
+    "if eigenvector_centrality_result.didConverge: \n",
+    "    print(f\"The number of iterations taken by Eigenvector Centrality to run is {eigenvector_centrality_result.ranIterations}.\")\n",
+    "else:\n",
+    "    print(\"Algorithm did not converge!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also see the distribution of the eigenvector centrality measures using the below code. This will show us the minimum, maximum, mean and other statistical values for our centrality measure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'p99': 0.08469437807798386,\n",
+       " 'min': 0.0012630745768547058,\n",
+       " 'max': 0.0856785699725151,\n",
+       " 'mean': 0.041094380038741385,\n",
+       " 'p90': 0.07575749605894089,\n",
+       " 'p50': 0.0386042520403862,\n",
+       " 'p999': 0.0856785699725151,\n",
+       " 'p95': 0.08167456835508347,\n",
+       " 'p75': 0.05822562426328659}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "eigenvector_centrality_result.centralityDistribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "writeMillis                              405\n",
+       "graphName                            airline\n",
+       "nodeProperties       [eigenvectorCentrality]\n",
+       "propertiesWritten                        456\n",
+       "Name: 0, dtype: object"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gds.graph.nodeProperties.write(G, [\"eigenvectorCentrality\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using the results from eigenvector centrality, we can now look up the top 20 cities with airports that have major hubs or airports with extensive connectivity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    node_id                     name  population  eigenvectorCentrality\n",
+      "0       246          Los Angeles, CA  12940000.0               0.085678\n",
+      "1       368        San Francisco, CA   4391000.0               0.085393\n",
+      "2        94    Dallas/Fort Worth, TX   6527000.0               0.085097\n",
+      "3       230            Las Vegas, NV   1970000.0               0.084824\n",
+      "4        74              Chicago, IL   9505000.0               0.084694\n",
+      "5       100               Denver, CO   2600000.0               0.084620\n",
+      "6       324              Phoenix, AZ   4263000.0               0.084607\n",
+      "7       383       Seattle/Tacoma, WA   3500000.0               0.084396\n",
+      "8       434           Washington, DC   5704000.0               0.084002\n",
+      "9       269  Minneapolis/St Paul, MN   3318000.0               0.083769\n",
+      "10      294             New York, NY  19020000.0               0.083696\n",
+      "11      323         Philadelphia, PA   5992000.0               0.083678\n",
+      "12      102              Detroit, MI   4286000.0               0.082966\n",
+      "13      178              Houston, TX   6087000.0               0.082904\n",
+      "14      136       Ft. Lauderdale, FL   5670000.0               0.082483\n",
+      "15       68            Charlotte, NC   1795000.0               0.082441\n",
+      "16       19              Atlanta, GA   5359000.0               0.082405\n",
+      "17       46               Boston, MA   4591000.0               0.082311\n",
+      "18      308              Orlando, FL   2171000.0               0.081994\n",
+      "19      266                Miami, FL   5670000.0               0.081949\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Execute the Cypher query to retrieve the top 20 cities with eigenvector centrality\n",
+    "query = \"\"\"\n",
+    "MATCH (n:City)\n",
+    "RETURN n.node_id AS node_id, n.name AS name, n.population AS population, n.eigenvectorCentrality AS eigenvectorCentrality\n",
+    "ORDER BY n.eigenvectorCentrality DESC\n",
+    "LIMIT 20\n",
+    "\"\"\"\n",
+    "result = gds.run_cypher(query)\n",
+    "\n",
+    "# Display the result\n",
+    "print(result)"
    ]
   },
   {
@@ -201,6 +560,118 @@
    "metadata": {},
    "outputs": [],
    "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Cleanup\n",
+    "\n",
+    "Before finishing we can clean up the example data from both the GDS in-memory state and the database."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "graphName                                                          airline\n",
+       "database                                                             neo4j\n",
+       "memoryUsage                                                               \n",
+       "sizeInBytes                                                             -1\n",
+       "nodeCount                                                              456\n",
+       "relationshipCount                                                    71959\n",
+       "configuration            {'relationshipProjection': {'HAS_FLIGHT_TO': {...\n",
+       "density                                                           0.346824\n",
+       "creationTime                           2023-05-31T16:40:51.805849930+00:00\n",
+       "modificationTime                       2023-05-31T16:58:18.406045233+00:00\n",
+       "schema                   {'graphProperties': {}, 'relationships': {'HAS...\n",
+       "schemaWithOrientation    {'graphProperties': {}, 'relationships': {'HAS...\n",
+       "Name: 0, dtype: object"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Cleanup GDS\n",
+    "G.drop()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Empty DataFrame\n",
+       "Columns: []\n",
+       "Index: []"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Cleanup database\n",
+    "gds.run_cypher(\"MATCH (n:City) DETACH DELETE n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### References\n",
+    "- For the network:\n",
+    "Brendan J. Frey and Delbert Dueck. \"Clustering by passing messages between data points.\" Science 315.5814 (2007): 972-976.\n",
+    "\n",
+    "- For the city metadata (metropolitan population, latitude, and longitude):\n",
+    "Austin R. Benson, David F. Gleich, and Jure Leskovec. \"Higher-order Organization of Complex Networks.\" Science, 353.6295 (2016): 163–166.\n",
+    "\n",
+    "- Notebook contributed by [Kedar Ghule](https://github.com/kedarghule)"
+   ]
   }
  ],
  "metadata": {

--- a/examples/centrality-algorithms.ipynb
+++ b/examples/centrality-algorithms.ipynb
@@ -1,0 +1,227 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Centrality Algorithms"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/neo4j/graph-data-science-client/blob/main/examples/centrality-algorithms.ipynb\">\n",
+    "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
+    "</a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This Jupyter notebook is hosted [here](https://github.com/neo4j/graph-data-science-client/blob/main/examples/centrality-algorithms.ipynb) in the Neo4j Graph Data Science Client Github repository.\n",
+    "\n",
+    "Centrality algorithms are used to understand the role or influence of particular nodes in a graph. The notebook shows the application of centrality algorithms using the `graphdatascience` library on the Airline travel reachability network dataset that can be downloaded [here](https://snap.stanford.edu/data/reachability.html).\n",
+    "\n",
+    "< TALK ABOUT TASKS >\n",
+    "\n",
+    "### Setup\n",
+    "\n",
+    "We start by importing our dependencies and setting up our GDS client connection to the database."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install necessary dependencies\n",
+    "#%pip install graphdatascience pandas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\kedar\\anaconda3\\envs\\graph_stuff\\lib\\site-packages\\tqdm\\auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
+   "source": [
+    "from graphdatascience import GraphDataScience\n",
+    "import pandas as pd\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NEO4J_URI = os.environ.get(\"NEO4J_URI\", \"bolt://localhost:7687\")\n",
+    "# NEO4J_AUTH = None\n",
+    "# if os.environ.get(\"NEO4J_USER\") and os.environ.get(\"NEO4J_PASSWORD\"):\n",
+    "#     NEO4J_AUTH = (\n",
+    "#         os.environ.get(\"NEO4J_USER\"),\n",
+    "#         os.environ.get(\"NEO4J_PASSWORD\"),\n",
+    "#     )\n",
+    "\n",
+    "# gds = GraphDataScience(NEO4J_URI, auth=NEO4J_AUTH)\n",
+    "\n",
+    "# # Replace with the actual connection URI and credentials\n",
+    "NEO4J_CONNECTION_URI = \"bolt://XXXXXXXXXXXXX\n",
+    "NEO4J_USERNAME = \"neo4j\"\n",
+    "NEO4J_PASSWORD = \"XXXXXXXXXXXXX\"\n",
+    "\n",
+    "# Client instantiation\n",
+    "gds = GraphDataScience(\n",
+    "    NEO4J_CONNECTION_URI,\n",
+    "    auth=(NEO4J_USERNAME, NEO4J_PASSWORD)\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Importing the dataset\n",
+    "\n",
+    "We import the dataset as a pandas dataframe first. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>node_id</th>\n",
+       "      <th>name</th>\n",
+       "      <th>metro_pop</th>\n",
+       "      <th>latitude</th>\n",
+       "      <th>longitude</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>Abbotsford, BC</td>\n",
+       "      <td>133497.0</td>\n",
+       "      <td>49.051575</td>\n",
+       "      <td>-122.328849</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>Aberdeen, SD</td>\n",
+       "      <td>40878.0</td>\n",
+       "      <td>45.459090</td>\n",
+       "      <td>-98.487324</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2</td>\n",
+       "      <td>Abilene, TX</td>\n",
+       "      <td>166416.0</td>\n",
+       "      <td>32.449175</td>\n",
+       "      <td>-99.741424</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3</td>\n",
+       "      <td>Akron/Canton, OH</td>\n",
+       "      <td>701456.0</td>\n",
+       "      <td>40.797810</td>\n",
+       "      <td>-81.371567</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>4</td>\n",
+       "      <td>Alamosa, CO</td>\n",
+       "      <td>9433.0</td>\n",
+       "      <td>37.468180</td>\n",
+       "      <td>-105.873599</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   node_id              name  metro_pop   latitude   longitude\n",
+       "0        0    Abbotsford, BC   133497.0  49.051575 -122.328849\n",
+       "1        1      Aberdeen, SD    40878.0  45.459090  -98.487324\n",
+       "2        2       Abilene, TX   166416.0  32.449175  -99.741424\n",
+       "3        3  Akron/Canton, OH   701456.0  40.797810  -81.371567\n",
+       "4        4       Alamosa, CO     9433.0  37.468180 -105.873599"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = pd.read_csv('https://snap.stanford.edu/data/reachability-meta.csv.gz', compression='gzip')\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/centrality-algorithms.ipynb
+++ b/examples/centrality-algorithms.ipynb
@@ -38,23 +38,14 @@
    "outputs": [],
    "source": [
     "# Install necessary dependencies\n",
-    "#%pip install graphdatascience pandas"
+    "# %pip install graphdatascience pandas"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\kedar\\anaconda3\\envs\\graph_stuff\\lib\\site-packages\\tqdm\\auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from graphdatascience import GraphDataScience\n",
     "import pandas as pd\n",
@@ -63,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,183 +80,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>node_id</th>\n",
-       "      <th>name</th>\n",
-       "      <th>metro_pop</th>\n",
-       "      <th>latitude</th>\n",
-       "      <th>longitude</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>0</td>\n",
-       "      <td>Abbotsford, BC</td>\n",
-       "      <td>133497.0</td>\n",
-       "      <td>49.051575</td>\n",
-       "      <td>-122.328849</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>1</td>\n",
-       "      <td>Aberdeen, SD</td>\n",
-       "      <td>40878.0</td>\n",
-       "      <td>45.459090</td>\n",
-       "      <td>-98.487324</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>2</td>\n",
-       "      <td>Abilene, TX</td>\n",
-       "      <td>166416.0</td>\n",
-       "      <td>32.449175</td>\n",
-       "      <td>-99.741424</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>3</td>\n",
-       "      <td>Akron/Canton, OH</td>\n",
-       "      <td>701456.0</td>\n",
-       "      <td>40.797810</td>\n",
-       "      <td>-81.371567</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>4</td>\n",
-       "      <td>Alamosa, CO</td>\n",
-       "      <td>9433.0</td>\n",
-       "      <td>37.468180</td>\n",
-       "      <td>-105.873599</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   node_id              name  metro_pop   latitude   longitude\n",
-       "0        0    Abbotsford, BC   133497.0  49.051575 -122.328849\n",
-       "1        1      Aberdeen, SD    40878.0  45.459090  -98.487324\n",
-       "2        2       Abilene, TX   166416.0  32.449175  -99.741424\n",
-       "3        3  Akron/Canton, OH   701456.0  40.797810  -81.371567\n",
-       "4        4       Alamosa, CO     9433.0  37.468180 -105.873599"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "nodes_info_df = pd.read_csv('https://snap.stanford.edu/data/reachability-meta.csv.gz', compression='gzip')\n",
+    "nodes_info_df = pd.read_csv(\"https://snap.stanford.edu/data/reachability-meta.csv.gz\", compression=\"gzip\")\n",
     "nodes_info_df.head()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Origin</th>\n",
-       "      <th>Destination</th>\n",
-       "      <th>Weight</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>27</td>\n",
-       "      <td>0</td>\n",
-       "      <td>-757</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>57</td>\n",
-       "      <td>0</td>\n",
-       "      <td>-84</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>70</td>\n",
-       "      <td>0</td>\n",
-       "      <td>-1290</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>74</td>\n",
-       "      <td>0</td>\n",
-       "      <td>-465</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>86</td>\n",
-       "      <td>0</td>\n",
-       "      <td>-700</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   Origin  Destination  Weight\n",
-       "0      27            0    -757\n",
-       "1      57            0     -84\n",
-       "2      70            0   -1290\n",
-       "3      74            0    -465\n",
-       "4      86            0    -700"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "routes_df = pd.read_csv('https://snap.stanford.edu/data/reachability.txt.gz', sep=' ', skiprows=6, header=None, compression='gzip', names=['Origin', 'Destination', 'Weight'])\n",
+    "routes_df = pd.read_csv(\n",
+    "    \"https://snap.stanford.edu/data/reachability.txt.gz\",\n",
+    "    sep=\" \",\n",
+    "    skiprows=6,\n",
+    "    header=None,\n",
+    "    compression=\"gzip\",\n",
+    "    names=[\"Origin\", \"Destination\", \"Weight\"],\n",
+    ")\n",
     "routes_df.head()"
    ]
   },
@@ -278,48 +114,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "Empty DataFrame\n",
-       "Columns: []\n",
-       "Index: []"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "gds.run_cypher(\n",
     "    \"UNWIND $nodes AS node CREATE (n:City {node_id: node.node_id, name: node.name, population: node.metro_pop})\",\n",
@@ -338,26 +135,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Loading: 100%|██████████| 100.0/100 [00:09<00:00, 10.76%/s] \n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The projection took 10123 ms\n",
-      "Graph 'airline' node count: 456\n",
-      "Graph 'airline' node labels: ['City']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "G, result = gds.graph.project(\"airline\", \"City\", \"HAS_FLIGHT_TO\")\n",
     "\n",
@@ -381,38 +161,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "PageRank: 100%|██████████| 100.0/100 [00:03<00:00, 28.58%/s]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "eigenvector_centrality_result = gds.eigenvector.mutate(G, maxIterations=100, mutateProperty=\"eigenvectorCentrality\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "City    [eigenvectorCentrality]\n",
-       "dtype: object"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# We can verify that the eigenvectorCentrality was mutated\n",
     "G.node_properties()"
@@ -427,20 +187,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The number of iterations taken by Eigenvector Centrality to run is 13.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "if eigenvector_centrality_result.didConverge: \n",
-    "    print(f\"The number of iterations taken by Eigenvector Centrality to run is {eigenvector_centrality_result.ranIterations}.\")\n",
+    "if eigenvector_centrality_result.didConverge:\n",
+    "    print(\n",
+    "        f\"The number of iterations taken by Eigenvector Centrality to run is {eigenvector_centrality_result.ranIterations}.\"\n",
+    "    )\n",
     "else:\n",
     "    print(\"Algorithm did not converge!\")"
    ]
@@ -454,52 +208,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'p99': 0.08469437807798386,\n",
-       " 'min': 0.0012630745768547058,\n",
-       " 'max': 0.0856785699725151,\n",
-       " 'mean': 0.041094380038741385,\n",
-       " 'p90': 0.07575749605894089,\n",
-       " 'p50': 0.0386042520403862,\n",
-       " 'p999': 0.0856785699725151,\n",
-       " 'p95': 0.08167456835508347,\n",
-       " 'p75': 0.05822562426328659}"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "eigenvector_centrality_result.centralityDistribution"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "writeMillis                              401\n",
-       "graphName                            airline\n",
-       "nodeProperties       [eigenvectorCentrality]\n",
-       "propertiesWritten                        456\n",
-       "Name: 0, dtype: object"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "gds.graph.nodeProperties.write(G, [\"eigenvectorCentrality\"])"
    ]
@@ -513,37 +233,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    node_id                     name  population  eigenvectorCentrality\n",
-      "0       246          Los Angeles, CA  12940000.0               0.085678\n",
-      "1       368        San Francisco, CA   4391000.0               0.085393\n",
-      "2        94    Dallas/Fort Worth, TX   6527000.0               0.085097\n",
-      "3       230            Las Vegas, NV   1970000.0               0.084824\n",
-      "4        74              Chicago, IL   9505000.0               0.084694\n",
-      "5       100               Denver, CO   2600000.0               0.084620\n",
-      "6       324              Phoenix, AZ   4263000.0               0.084607\n",
-      "7       383       Seattle/Tacoma, WA   3500000.0               0.084396\n",
-      "8       434           Washington, DC   5704000.0               0.084002\n",
-      "9       269  Minneapolis/St Paul, MN   3318000.0               0.083769\n",
-      "10      294             New York, NY  19020000.0               0.083696\n",
-      "11      323         Philadelphia, PA   5992000.0               0.083678\n",
-      "12      102              Detroit, MI   4286000.0               0.082966\n",
-      "13      178              Houston, TX   6087000.0               0.082904\n",
-      "14      136       Ft. Lauderdale, FL   5670000.0               0.082483\n",
-      "15       68            Charlotte, NC   1795000.0               0.082441\n",
-      "16       19              Atlanta, GA   5359000.0               0.082405\n",
-      "17       46               Boston, MA   4591000.0               0.082311\n",
-      "18      308              Orlando, FL   2171000.0               0.081994\n",
-      "19      266                Miami, FL   5670000.0               0.081949\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "def display_top_20_cities(centrality_measure):\n",
     "    \"\"\"\n",
@@ -559,7 +251,8 @@
     "\n",
     "    # Display the result\n",
     "    print(result)\n",
-    "    \n",
+    "\n",
+    "\n",
     "display_top_20_cities(\"eigenvectorCentrality\")"
    ]
   },
@@ -576,38 +269,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "BetweennessCentrality: 100%|██████████| 100.0/100 [00:04<00:00, 22.07%/s]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "betweenness_centrality_result = gds.betweenness.mutate(G, mutateProperty=\"betweennessCentrality\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "City    [betweennessCentrality, eigenvectorCentrality]\n",
-       "dtype: object"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# We can verify that the betweennessCentrality was mutated\n",
     "G.node_properties()"
@@ -622,52 +295,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'p99': 3265.2968747615814,\n",
-       " 'min': 0.04446244239807129,\n",
-       " 'max': 3628.7656247615814,\n",
-       " 'mean': 298.0898581821668,\n",
-       " 'p90': 1006.8867185115814,\n",
-       " 'p50': 21.20861792564392,\n",
-       " 'p999': 3628.7656247615814,\n",
-       " 'p95': 1823.7578122615814,\n",
-       " 'p75': 184.29199194908142}"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "betweenness_centrality_result.centralityDistribution"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "writeMillis                              147\n",
-       "graphName                            airline\n",
-       "nodeProperties       [betweennessCentrality]\n",
-       "propertiesWritten                        456\n",
-       "Name: 0, dtype: object"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "gds.graph.nodeProperties.write(G, [\"betweennessCentrality\"])"
    ]
@@ -681,37 +320,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    node_id                     name  population  betweennessCentrality\n",
-      "0       246          Los Angeles, CA  12940000.0            3628.755650\n",
-      "1       100               Denver, CO   2600000.0            3435.693657\n",
-      "2       294             New York, NY  19020000.0            3297.750685\n",
-      "3       416              Toronto, ON   6324000.0            3295.316691\n",
-      "4       368        San Francisco, CA   4391000.0            3265.288064\n",
-      "5        74              Chicago, IL   9505000.0            3250.731388\n",
-      "6       230            Las Vegas, NV   1970000.0            3156.983626\n",
-      "7       434           Washington, DC   5704000.0            3108.796793\n",
-      "8        94    Dallas/Fort Worth, TX   6527000.0            3094.760797\n",
-      "9       324              Phoenix, AZ   4263000.0            2815.294080\n",
-      "10      383       Seattle/Tacoma, WA   3500000.0            2600.388338\n",
-      "11      269  Minneapolis/St Paul, MN   3318000.0            2386.544069\n",
-      "12      367            San Diego, CA   3140000.0            2225.911712\n",
-      "13      178              Houston, TX   6087000.0            2206.757554\n",
-      "14      308              Orlando, FL   2171000.0            2205.127484\n",
-      "15       46               Boston, MA   4591000.0            2192.597357\n",
-      "16      331             Portland, OR   2263000.0            2098.582191\n",
-      "17      136       Ft. Lauderdale, FL   5670000.0            2047.102205\n",
-      "18      323         Philadelphia, PA   5992000.0            2038.406177\n",
-      "19      402            St. Louis, MO   2817000.0            1961.619874\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "display_top_20_cities(\"betweennessCentrality\")"
    ]
@@ -729,7 +340,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -738,21 +349,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "City    [betweennessCentrality, eigenvectorCentrality,...\n",
-       "dtype: object"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# We can verify that the degreeCentrality was mutated\n",
     "G.node_properties()"
@@ -767,52 +366,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'p99': 429.0019226074219,\n",
-       " 'min': 5.0,\n",
-       " 'max': 443.0019226074219,\n",
-       " 'mean': 157.80525314598754,\n",
-       " 'p90': 329.0019226074219,\n",
-       " 'p50': 126.00045776367188,\n",
-       " 'p999': 443.0019226074219,\n",
-       " 'p95': 384.0019226074219,\n",
-       " 'p75': 217.00094604492188}"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "degree_centrality_result.centralityDistribution"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "writeMillis                         182\n",
-       "graphName                       airline\n",
-       "nodeProperties       [degreeCentrality]\n",
-       "propertiesWritten                   456\n",
-       "Name: 0, dtype: object"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "gds.graph.nodeProperties.write(G, [\"degreeCentrality\"])"
    ]
@@ -826,37 +391,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "    node_id                      name  population  degreeCentrality\n",
-      "0       246           Los Angeles, CA  12940000.0             443.0\n",
-      "1       230             Las Vegas, NV   1970000.0             432.0\n",
-      "2       368         San Francisco, CA   4391000.0             430.0\n",
-      "3        74               Chicago, IL   9505000.0             430.0\n",
-      "4       100                Denver, CO   2600000.0             429.0\n",
-      "5       294              New York, NY  19020000.0             428.0\n",
-      "6        94     Dallas/Fort Worth, TX   6527000.0             427.0\n",
-      "7       434            Washington, DC   5704000.0             427.0\n",
-      "8       324               Phoenix, AZ   4263000.0             424.0\n",
-      "9       416               Toronto, ON   6324000.0             409.0\n",
-      "10      269   Minneapolis/St Paul, MN   3318000.0             406.0\n",
-      "11      383        Seattle/Tacoma, WA   3500000.0             406.0\n",
-      "12       46                Boston, MA   4591000.0             404.0\n",
-      "13      323          Philadelphia, PA   5992000.0             402.0\n",
-      "14      367             San Diego, CA   3140000.0             402.0\n",
-      "15      136        Ft. Lauderdale, FL   5670000.0             401.0\n",
-      "16      178               Houston, TX   6087000.0             400.0\n",
-      "17      308               Orlando, FL   2171000.0             398.0\n",
-      "18      266                 Miami, FL   5670000.0             395.0\n",
-      "19      408  Tampa/St. Petersburg, FL   2825000.0             394.0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "display_top_20_cities(\"degreeCentrality\")"
    ]
@@ -872,32 +409,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "graphName                                                          airline\n",
-       "database                                                             neo4j\n",
-       "memoryUsage                                                               \n",
-       "sizeInBytes                                                             -1\n",
-       "nodeCount                                                              456\n",
-       "relationshipCount                                                    71959\n",
-       "configuration            {'relationshipProjection': {'HAS_FLIGHT_TO': {...\n",
-       "density                                                           0.346824\n",
-       "creationTime                           2023-05-31T21:40:56.026577291+00:00\n",
-       "modificationTime                       2023-05-31T21:51:11.923884431+00:00\n",
-       "schema                   {'graphProperties': {}, 'relationships': {'HAS...\n",
-       "schemaWithOrientation    {'graphProperties': {}, 'relationships': {'HAS...\n",
-       "Name: 0, dtype: object"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Cleanup GDS\n",
     "G.drop()"
@@ -905,48 +419,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "Empty DataFrame\n",
-       "Columns: []\n",
-       "Index: []"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Cleanup database\n",
     "gds.run_cypher(\"MATCH (n:City) DETACH DELETE n\")"
@@ -968,22 +443,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/examples/centrality-algorithms.ipynb
+++ b/examples/centrality-algorithms.ipynb
@@ -109,7 +109,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we load this data (nodes and edges) into a Graph Database and a GDS graph."
+    "Since this graph is very small, a straight-forward Cypher `UNWIND` query is the simplest way to create our graph in the database.\n",
+    "\n",
+    "Larger graphs may need a more sophisticated importing technique like batching, `neo4j-admin import` or Arrow `CREATE DATABASE`."
    ]
   },
   {
@@ -145,7 +147,8 @@
     "\n",
     "# We can use convenience methods on `G` to check if the projection looks correct\n",
     "print(f\"Graph '{G.name()}' node count: {G.node_count()}\")\n",
-    "print(f\"Graph '{G.name()}' node labels: {G.node_labels()}\")"
+    "print(f\"Graph '{G.name()}' node labels: {G.node_labels()}\")\n",
+    "print(f\"Graph '{G.name()}' relationship count: {G.relationship_count()}\")"
    ]
   },
   {
@@ -213,6 +216,13 @@
    "outputs": [],
    "source": [
     "eigenvector_centrality_result.centralityDistribution"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will now write our results back to the database."
    ]
   },
   {
@@ -303,6 +313,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will now write our results back to the database."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -374,6 +391,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will now write our results back to the database."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -438,13 +462,29 @@
     "- For the city metadata (metropolitan population, latitude, and longitude):\n",
     "Austin R. Benson, David F. Gleich, and Jure Leskovec. \"Higher-order Organization of Complex Networks.\" Science, 353.6295 (2016): 163–166.\n",
     "\n",
+    "- Link to the dataset: https://snap.stanford.edu/data/reachability.html\n",
+    "\n",
     "- Notebook contributed by [Kedar Ghule](https://github.com/kedarghule)"
    ]
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,

--- a/examples/centrality-algorithms.ipynb
+++ b/examples/centrality-algorithms.ipynb
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,26 +67,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# NEO4J_URI = os.environ.get(\"NEO4J_URI\", \"bolt://localhost:7687\")\n",
-    "# NEO4J_AUTH = None\n",
-    "# if os.environ.get(\"NEO4J_USER\") and os.environ.get(\"NEO4J_PASSWORD\"):\n",
-    "#     NEO4J_AUTH = (\n",
-    "#         os.environ.get(\"NEO4J_USER\"),\n",
-    "#         os.environ.get(\"NEO4J_PASSWORD\"),\n",
-    "#     )\n",
+    "NEO4J_URI = os.environ.get(\"NEO4J_URI\", \"bolt://localhost:7687\")\n",
+    "NEO4J_AUTH = None\n",
+    "if os.environ.get(\"NEO4J_USER\") and os.environ.get(\"NEO4J_PASSWORD\"):\n",
+    "    NEO4J_AUTH = (\n",
+    "        os.environ.get(\"NEO4J_USER\"),\n",
+    "        os.environ.get(\"NEO4J_PASSWORD\"),\n",
+    "    )\n",
     "\n",
-    "# gds = GraphDataScience(NEO4J_URI, auth=NEO4J_AUTH)\n",
-    "\n",
-    "# # Replace with the actual connection URI and credentials\n",
-    "NEO4J_CONNECTION_URI = \"bolt://3.235.129.183:7687\"\n",
-    "NEO4J_USERNAME = \"neo4j\"\n",
-    "NEO4J_PASSWORD = \"incentives-sevenths-pear\"\n",
-    "\n",
-    "# Client instantiation\n",
-    "gds = GraphDataScience(\n",
-    "    NEO4J_CONNECTION_URI,\n",
-    "    auth=(NEO4J_USERNAME, NEO4J_PASSWORD)\n",
-    ")\n"
+    "gds = GraphDataScience(NEO4J_URI, auth=NEO4J_AUTH)"
    ]
   },
   {
@@ -353,10 +342,17 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Loading: 100%|██████████| 100.0/100 [00:09<00:00, 10.76%/s] \n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The projection took 214 ms\n",
+      "The projection took 10123 ms\n",
       "Graph 'airline' node count: 456\n",
       "Graph 'airline' node labels: ['City']\n"
      ]
@@ -387,14 +383,22 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "PageRank: 100%|██████████| 100.0/100 [00:03<00:00, 28.58%/s]\n"
+     ]
+    }
+   ],
    "source": [
     "eigenvector_centrality_result = gds.eigenvector.mutate(G, maxIterations=100, mutateProperty=\"eigenvectorCentrality\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -404,7 +408,7 @@
        "dtype: object"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -423,7 +427,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -450,7 +454,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -467,7 +471,7 @@
        " 'p75': 0.05822562426328659}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -478,20 +482,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "writeMillis                              405\n",
+       "writeMillis                              401\n",
        "graphName                            airline\n",
        "nodeProperties       [eigenvectorCentrality]\n",
        "propertiesWritten                        456\n",
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -509,7 +513,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -541,17 +545,22 @@
     }
    ],
    "source": [
-    "# Execute the Cypher query to retrieve the top 20 cities with eigenvector centrality\n",
-    "query = \"\"\"\n",
-    "MATCH (n:City)\n",
-    "RETURN n.node_id AS node_id, n.name AS name, n.population AS population, n.eigenvectorCentrality AS eigenvectorCentrality\n",
-    "ORDER BY n.eigenvectorCentrality DESC\n",
-    "LIMIT 20\n",
-    "\"\"\"\n",
-    "result = gds.run_cypher(query)\n",
+    "def display_top_20_cities(centrality_measure):\n",
+    "    \"\"\"\n",
+    "    Function to execute the Cypher query to retrieve the top 20 cities with the highest centrality measure.\n",
+    "    \"\"\"\n",
+    "    query = f\"\"\"\n",
+    "    MATCH (n:City)\n",
+    "    RETURN n.node_id AS node_id, n.name AS name, n.population AS population, n.{centrality_measure} AS {centrality_measure}\n",
+    "    ORDER BY n.{centrality_measure} DESC\n",
+    "    LIMIT 20\n",
+    "    \"\"\"\n",
+    "    result = gds.run_cypher(query)\n",
     "\n",
-    "# Display the result\n",
-    "print(result)"
+    "    # Display the result\n",
+    "    print(result)\n",
+    "    \n",
+    "display_top_20_cities(\"eigenvectorCentrality\")"
    ]
   },
   {
@@ -574,9 +583,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Failed to write data to connection IPv4Address(('3.235.129.183', 7687)) (ResolvedIPv4Address(('3.235.129.183', 7687)))\n",
-      "Failed to write data to connection IPv4Address(('3.235.129.183', 7687)) (ResolvedIPv4Address(('3.235.129.183', 7687)))\n",
-      "BetweennessCentrality: 100%|██████████| 100.0/100 [00:04<00:00, 22.62%/s]\n"
+      "BetweennessCentrality: 100%|██████████| 100.0/100 [00:04<00:00, 22.07%/s]\n"
      ]
     }
    ],
@@ -649,7 +656,7 @@
     {
      "data": {
       "text/plain": [
-       "writeMillis                               95\n",
+       "writeMillis                              147\n",
        "graphName                            airline\n",
        "nodeProperties       [betweennessCentrality]\n",
        "propertiesWritten                        456\n",
@@ -706,30 +713,152 @@
     }
    ],
    "source": [
-    "# Execute the Cypher query to retrieve the top 20 cities with betweenness centrality\n",
-    "query = \"\"\"\n",
-    "MATCH (n:City)\n",
-    "RETURN n.node_id AS node_id, n.name AS name, n.population AS population, n.betweennessCentrality AS betweennessCentrality\n",
-    "ORDER BY n.betweennessCentrality DESC\n",
-    "LIMIT 20\n",
-    "\"\"\"\n",
-    "result = gds.run_cypher(query)\n",
+    "display_top_20_cities(\"betweennessCentrality\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Degree Centrality\n",
     "\n",
-    "# Display the result\n",
-    "print(result)"
+    "[Degree Centrality](https://neo4j.com/docs/graph-data-science/current/algorithms/degree-centrality/) measures the number of connections (edges) a node has in the network. \n",
+    "\n",
+    "For our dataset, cities with high degree centrality have a large number of direct flight connections to other cities. They represent cities that have many direct destinations or are frequently used for direct travel. Degree centrality provides insights into the prominence and connectivity of individual airports within the network."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
-    "### Betweenness Centrality\n",
-    "\n",
-    "[Betweenness Centrality](https://neo4j.com/docs/graph-data-science/current/algorithms/betweenness-centrality/) quantifies the importance of a node as a bridge or intermediary in the network. It measures how often a node lies on the shortest path between other pairs of nodes. \n",
-    "\n",
-    "For our dataset, cities/airports with high betweenness centrality serve as crucial transfer points or connecting hubs between airports that might not have direct flights between them. They play a significant role in facilitating the flow of air travel and can be vital for overall network connectivity."
+    "degree_centrality_result = gds.degree.mutate(G, mutateProperty=\"degreeCentrality\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "City    [betweennessCentrality, eigenvectorCentrality,...\n",
+       "dtype: object"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# We can verify that the degreeCentrality was mutated\n",
+    "G.node_properties()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Similar to above, we can also see the distribution of the degree centrality measures using the below code. This will show us the minimum, maximum, mean and other statistical values for our centrality measure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'p99': 429.0019226074219,\n",
+       " 'min': 5.0,\n",
+       " 'max': 443.0019226074219,\n",
+       " 'mean': 157.80525314598754,\n",
+       " 'p90': 329.0019226074219,\n",
+       " 'p50': 126.00045776367188,\n",
+       " 'p999': 443.0019226074219,\n",
+       " 'p95': 384.0019226074219,\n",
+       " 'p75': 217.00094604492188}"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "degree_centrality_result.centralityDistribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "writeMillis                         182\n",
+       "graphName                       airline\n",
+       "nodeProperties       [degreeCentrality]\n",
+       "propertiesWritten                   456\n",
+       "Name: 0, dtype: object"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gds.graph.nodeProperties.write(G, [\"degreeCentrality\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, using the results from degree centrality, we can now look up the top 20 cities with airports that have a large number of direct flights."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    node_id                      name  population  degreeCentrality\n",
+      "0       246           Los Angeles, CA  12940000.0             443.0\n",
+      "1       230             Las Vegas, NV   1970000.0             432.0\n",
+      "2       368         San Francisco, CA   4391000.0             430.0\n",
+      "3        74               Chicago, IL   9505000.0             430.0\n",
+      "4       100                Denver, CO   2600000.0             429.0\n",
+      "5       294              New York, NY  19020000.0             428.0\n",
+      "6        94     Dallas/Fort Worth, TX   6527000.0             427.0\n",
+      "7       434            Washington, DC   5704000.0             427.0\n",
+      "8       324               Phoenix, AZ   4263000.0             424.0\n",
+      "9       416               Toronto, ON   6324000.0             409.0\n",
+      "10      269   Minneapolis/St Paul, MN   3318000.0             406.0\n",
+      "11      383        Seattle/Tacoma, WA   3500000.0             406.0\n",
+      "12       46                Boston, MA   4591000.0             404.0\n",
+      "13      323          Philadelphia, PA   5992000.0             402.0\n",
+      "14      367             San Diego, CA   3140000.0             402.0\n",
+      "15      136        Ft. Lauderdale, FL   5670000.0             401.0\n",
+      "16      178               Houston, TX   6087000.0             400.0\n",
+      "17      308               Orlando, FL   2171000.0             398.0\n",
+      "18      266                 Miami, FL   5670000.0             395.0\n",
+      "19      408  Tampa/St. Petersburg, FL   2825000.0             394.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "display_top_20_cities(\"degreeCentrality\")"
    ]
   },
   {
@@ -743,7 +872,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -757,14 +886,14 @@
        "relationshipCount                                                    71959\n",
        "configuration            {'relationshipProjection': {'HAS_FLIGHT_TO': {...\n",
        "density                                                           0.346824\n",
-       "creationTime                           2023-05-31T16:40:51.805849930+00:00\n",
-       "modificationTime                       2023-05-31T16:58:18.406045233+00:00\n",
+       "creationTime                           2023-05-31T21:40:56.026577291+00:00\n",
+       "modificationTime                       2023-05-31T21:51:11.923884431+00:00\n",
        "schema                   {'graphProperties': {}, 'relationships': {'HAS...\n",
        "schemaWithOrientation    {'graphProperties': {}, 'relationships': {'HAS...\n",
        "Name: 0, dtype: object"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -776,7 +905,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -813,7 +942,7 @@
        "Index: []"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/examples/centrality-algorithms.ipynb
+++ b/examples/centrality-algorithms.ipynb
@@ -555,18 +555,182 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "### Betweenness Centrality\n",
+    "\n",
+    "[Betweenness Centrality](https://neo4j.com/docs/graph-data-science/current/algorithms/betweenness-centrality/) quantifies the importance of a node as a bridge or intermediary in the network. It measures how often a node lies on the shortest path between other pairs of nodes. \n",
+    "\n",
+    "For our dataset, cities/airports with high betweenness centrality serve as crucial transfer points or connecting hubs between airports that might not have direct flights between them. They play a significant role in facilitating the flow of air travel and can be vital for overall network connectivity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Failed to write data to connection IPv4Address(('3.235.129.183', 7687)) (ResolvedIPv4Address(('3.235.129.183', 7687)))\n",
+      "Failed to write data to connection IPv4Address(('3.235.129.183', 7687)) (ResolvedIPv4Address(('3.235.129.183', 7687)))\n",
+      "BetweennessCentrality: 100%|██████████| 100.0/100 [00:04<00:00, 22.62%/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "betweenness_centrality_result = gds.betweenness.mutate(G, mutateProperty=\"betweennessCentrality\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "City    [betweennessCentrality, eigenvectorCentrality]\n",
+       "dtype: object"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# We can verify that the betweennessCentrality was mutated\n",
+    "G.node_properties()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also see the distribution of the betweenness centrality measures using the below code. This will show us the minimum, maximum, mean and other statistical values for our centrality measure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'p99': 3265.2968747615814,\n",
+       " 'min': 0.04446244239807129,\n",
+       " 'max': 3628.7656247615814,\n",
+       " 'mean': 298.0898581821668,\n",
+       " 'p90': 1006.8867185115814,\n",
+       " 'p50': 21.20861792564392,\n",
+       " 'p999': 3628.7656247615814,\n",
+       " 'p95': 1823.7578122615814,\n",
+       " 'p75': 184.29199194908142}"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "betweenness_centrality_result.centralityDistribution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "writeMillis                               95\n",
+       "graphName                            airline\n",
+       "nodeProperties       [betweennessCentrality]\n",
+       "propertiesWritten                        456\n",
+       "Name: 0, dtype: object"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "gds.graph.nodeProperties.write(G, [\"betweennessCentrality\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using the results from betweenness centrality, we can now look up the top 20 cities with airports that serve as crucial transfer points or connecting hubs between airports that might not have direct flights between them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    node_id                     name  population  betweennessCentrality\n",
+      "0       246          Los Angeles, CA  12940000.0            3628.755650\n",
+      "1       100               Denver, CO   2600000.0            3435.693657\n",
+      "2       294             New York, NY  19020000.0            3297.750685\n",
+      "3       416              Toronto, ON   6324000.0            3295.316691\n",
+      "4       368        San Francisco, CA   4391000.0            3265.288064\n",
+      "5        74              Chicago, IL   9505000.0            3250.731388\n",
+      "6       230            Las Vegas, NV   1970000.0            3156.983626\n",
+      "7       434           Washington, DC   5704000.0            3108.796793\n",
+      "8        94    Dallas/Fort Worth, TX   6527000.0            3094.760797\n",
+      "9       324              Phoenix, AZ   4263000.0            2815.294080\n",
+      "10      383       Seattle/Tacoma, WA   3500000.0            2600.388338\n",
+      "11      269  Minneapolis/St Paul, MN   3318000.0            2386.544069\n",
+      "12      367            San Diego, CA   3140000.0            2225.911712\n",
+      "13      178              Houston, TX   6087000.0            2206.757554\n",
+      "14      308              Orlando, FL   2171000.0            2205.127484\n",
+      "15       46               Boston, MA   4591000.0            2192.597357\n",
+      "16      331             Portland, OR   2263000.0            2098.582191\n",
+      "17      136       Ft. Lauderdale, FL   5670000.0            2047.102205\n",
+      "18      323         Philadelphia, PA   5992000.0            2038.406177\n",
+      "19      402            St. Louis, MO   2817000.0            1961.619874\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Execute the Cypher query to retrieve the top 20 cities with betweenness centrality\n",
+    "query = \"\"\"\n",
+    "MATCH (n:City)\n",
+    "RETURN n.node_id AS node_id, n.name AS name, n.population AS population, n.betweennessCentrality AS betweennessCentrality\n",
+    "ORDER BY n.betweennessCentrality DESC\n",
+    "LIMIT 20\n",
+    "\"\"\"\n",
+    "result = gds.run_cypher(query)\n",
+    "\n",
+    "# Display the result\n",
+    "print(result)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "### Betweenness Centrality\n",
+    "\n",
+    "[Betweenness Centrality](https://neo4j.com/docs/graph-data-science/current/algorithms/betweenness-centrality/) quantifies the importance of a node as a bridge or intermediary in the network. It measures how often a node lies on the shortest path between other pairs of nodes. \n",
+    "\n",
+    "For our dataset, cities/airports with high betweenness centrality serve as crucial transfer points or connecting hubs between airports that might not have direct flights between them. They play a significant role in facilitating the flow of air travel and can be vital for overall network connectivity."
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
This PR adds an example jupyter notebook for centrality algorithms on the airline travel reachability network dataset. The notebook explores eigenvector centrality, betweenness centrality & degree centrality.

This is in reference to my comment in the issue: https://github.com/neo4j/graph-data-science-client/issues/254

Thank you :)