### PR TITLE
More neo4j theming

### DIFF
--- a/doc/sphinx/source/conf.py
+++ b/doc/sphinx/source/conf.py
@@ -42,6 +42,7 @@ html_theme_path = ["themes"]
 def setup(app):  # type: ignore
     app.add_js_file("https://neo4j.com/docs/assets/js/site.js", loading_method="defer")
     app.add_js_file("js/12-fragment-jumper.js", loading_method="defer")
+    app.add_js_file("js/deprecated.js", loading_method="defer")
 
 
 rst_epilog = """

--- a/doc/sphinx/source/themes/neo4j/layout.html
+++ b/doc/sphinx/source/themes/neo4j/layout.html
@@ -7,6 +7,10 @@
 {%- block relbar1 %}{% endblock %}
 {%- block relbar2 %}{% endblock %}
 
+{% block extrahead %}
+<link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@300;400;600;700&display=swap" rel="stylesheet">
+{% endblock %}
+
 {%- block content %}
 <body class="article docs sphinx">
 
@@ -16,9 +20,9 @@
   <nav class="navbar">
     <div class="navbar-brand">
       <a class="navbar-item" href="/">
-
-      <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20210422142941/neo4j-logo-2020.svg" alt="Neo4j Graph Data Science Client API Reference">
-      </a><a href="/docs/" class="navbar-item no-left-padding" aria-label="Neo4j Graph Data Science Client API Reference">
+        <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20210422142941/neo4j-logo-2020.svg" alt="Neo4j Graph Data Science Client API Reference">
+      </a>
+      <a href="/docs/graph-data-science-client" class="navbar-item no-left-padding" aria-label="Neo4j Graph Data Science Client API Reference">
         Graph Data Science Client API Reference
       </a>
 

--- a/doc/sphinx/source/themes/neo4j/layout.html
+++ b/doc/sphinx/source/themes/neo4j/layout.html
@@ -22,7 +22,7 @@
       <a class="navbar-item" href="/">
         <img class="navbar-logo" src="https://dist.neo4j.com/wp-content/uploads/20210422142941/neo4j-logo-2020.svg" alt="Neo4j Graph Data Science Client API Reference">
       </a>
-      <a href="/docs/graph-data-science-client" class="navbar-item no-left-padding" aria-label="Neo4j Graph Data Science Client API Reference">
+      <a href="{{ pathto(root_doc) }}" class="navbar-item no-left-padding" aria-label="Neo4j Graph Data Science Client API Reference">
         Graph Data Science Client API Reference
       </a>
 

--- a/doc/sphinx/source/themes/neo4j/static/css/neo4j.css
+++ b/doc/sphinx/source/themes/neo4j/static/css/neo4j.css
@@ -56,6 +56,10 @@ body.sphinx .content .search {
         height: auto;
         background: initial;
     }
+
+    body.sphinx .sphinxsidebar {
+        background: #f5f7fa;
+    }
     
     body.sphinx .nav-panel-menu:not(.is-active)::after {
         background: initial;
@@ -189,4 +193,41 @@ div.code-block-caption:hover > a.headerlink {
     font-weight: 400;
     display: block;
     padding: 0.25rem 0;
+}
+
+/* lists */
+
+body.sphinx .doc ul li{
+    margin-bottom: 0.5rem;
+}
+
+/* functions */
+
+body.sphinx .doc dl.py.function {
+    padding-top: 2rem;
+    padding: 1rem;
+    /* border-top: 2px dotted #eee; */
+}
+
+/*  deprecated */
+
+body.sphinx .deprecated::after,
+body.sphinx .deprecated > *::after {
+    content: unset;
+}
+
+body.sphinx .doc dl.deprecated,
+body.sphinx .doc div.deprecated {
+    border-left: 4px solid #d53f8c;
+    color: #702459;
+    background-color: #fed7e2;
+}
+
+body.sphinx .doc dl.deprecated {
+    margin-bottom: 0;
+    padding-bottom: 0;
+}
+
+body.sphinx .doc div.deprecated {
+    padding: 1rem;
 }

--- a/doc/sphinx/source/themes/neo4j/static/css/neo4j.css
+++ b/doc/sphinx/source/themes/neo4j/static/css/neo4j.css
@@ -216,11 +216,11 @@ body.sphinx .deprecated > *::after {
     content: unset;
 }
 
-body.sphinx .doc dl.deprecated,
-body.sphinx .doc div.deprecated {
-    border-left: 4px solid #d53f8c;
-    color: #702459;
-    background-color: #fed7e2;
+body.sphinx .doc dl.deprecated dt:first-of-type span.sig-prename, 
+body.sphinx .doc dl.deprecated dt:first-of-type span.sig-name {
+    border-bottom: 1px solid #f6ad55;
+    /* color: #702459; */
+    /* background-color: #fed7e2; */
 }
 
 body.sphinx .doc dl.deprecated {
@@ -230,4 +230,8 @@ body.sphinx .doc dl.deprecated {
 
 body.sphinx .doc div.deprecated {
     padding: 1rem;
+    margin: 0 2rem;
+    /* color: #702459; */
+    border-left: 2px solid #f6ad55;
+    background-color: #fffaf0;
 }

--- a/doc/sphinx/source/themes/neo4j/static/js/deprecated.js
+++ b/doc/sphinx/source/themes/neo4j/static/js/deprecated.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const deprecatedDivs = document.querySelectorAll('div.deprecated')
+    deprecatedDivs.forEach(function (deprecatedDiv) {
+
+    // get previous sibling
+    const previousSibling = deprecatedDiv.previousElementSibling
+    // add deprecated class to previous sibling
+    previousSibling.classList.add('deprecated')
+
+    })
+  })


### PR DESCRIPTION
Updates the Sphinx docs theme following feedback:

- Adds a background to the navigation to match other neo4j.com/docs pages
- Updates a header link target
- Fixes a rendering issue with deprecated content, removing the style that was inherited from the main docs assets and adding new styles to mark content as deprecated more clearly