### PR TITLE
Rename unpublished endpoint to gds.graph.filter

### DIFF
--- a/doc/sphinx/source/graph.rst
+++ b/doc/sphinx/source/graph.rst
@@ -48,7 +48,7 @@ These all assume that an object of :class:`.GraphDataScience` is available as `g
     Computes a random graph, which will be stored in the graph catalog.
 
 .. deprecated:: 2.5.0
-   Since GDS server version 2.5.0 you should use the endpoint :func:`gds.graph.project.subgraph` instead.
+   Since GDS server version 2.5.0 you should use the endpoint :func:`gds.graph.filter` instead.
 
 .. py:function:: gds.beta.graph.project.subgraph(graph_name: str,from_G: Graph,node_filter: str,relationship_filter: str,**config: Any,) -> GraphCreateResult
 

--- a/graphdatascience/graph/graph_proc_runner.py
+++ b/graphdatascience/graph/graph_proc_runner.py
@@ -25,7 +25,11 @@ from .graph_export_runner import GraphExportRunner
 from .graph_object import Graph
 from .graph_project_runner import GraphProjectRunner
 from .graph_sample_runner import GraphSampleRunner
-from .graph_type_check import graph_type_check, graph_type_check_optional
+from .graph_type_check import (
+    from_graph_type_check,
+    graph_type_check,
+    graph_type_check_optional,
+)
 from .ogb_loader import OGBLLoader, OGBNLoader
 from graphdatascience.graph.graph_create_result import GraphCreateResult
 from graphdatascience.graph.graph_cypher_runner import GraphCypherRunner
@@ -185,6 +189,29 @@ class GraphProcRunner(UncallableNamespace, IllegalAttrChecker):
         }
 
         result = self._query_runner.run_query(query, params).squeeze()
+
+        return GraphCreateResult(Graph(graph_name, self._query_runner, self._server_version), result)
+
+    @from_graph_type_check
+    def filter(
+        self,
+        graph_name: str,
+        from_G: Graph,
+        node_filter: str,
+        relationship_filter: str,
+        **config: Any,
+    ) -> GraphCreateResult:
+        self._namespace += ".filter"
+        result = self._query_runner.run_query_with_logging(
+            f"CALL {self._namespace}($graph_name, $from_graph_name, $node_filter, $relationship_filter, $config)",
+            {
+                "graph_name": graph_name,
+                "from_graph_name": from_G.name(),
+                "node_filter": node_filter,
+                "relationship_filter": relationship_filter,
+                "config": config,
+            },
+        ).squeeze()
 
         return GraphCreateResult(Graph(graph_name, self._query_runner, self._server_version), result)
 

--- a/graphdatascience/graph/graph_project_runner.py
+++ b/graphdatascience/graph/graph_project_runner.py
@@ -39,19 +39,6 @@ class GraphProjectRunner(IllegalAttrChecker):
     def cypher(self) -> "GraphProjectRunner":
         return GraphProjectRunner(self._query_runner, self._namespace + ".cypher", self._server_version)
 
-    @from_graph_type_check
-    def subgraph(
-        self,
-        graph_name: str,
-        from_G: Graph,
-        node_filter: str,
-        relationship_filter: str,
-        **config: Any,
-    ) -> GraphCreateResult:
-        # simple forward as the API did not change
-        runner = GraphProjectBetaRunner(self._query_runner, self._namespace, self._server_version)
-        return runner.subgraph(graph_name, from_G, node_filter, relationship_filter, **config)
-
 
 class GraphProjectBetaRunner(IllegalAttrChecker):
     @from_graph_type_check

--- a/graphdatascience/tests/integration/test_graph_ops.py
+++ b/graphdatascience/tests/integration/test_graph_ops.py
@@ -84,7 +84,7 @@ def test_cypher_projection(gds: GraphDataScience) -> None:
     assert result["exists"]
 
 
-@pytest.mark.filterwarnings("ignore: Deprecated in favor of gds.graph.project.subgraph")
+@pytest.mark.filterwarnings("ignore: Deprecated in favor of gds.graph.filter")
 def test_beta_project_subgraph(runner: QueryRunner, gds: GraphDataScience) -> None:
     from_G, _ = gds.graph.project(GRAPH_NAME, {"Node": {"properties": "x"}}, "*")
 
@@ -103,7 +103,7 @@ def test_beta_project_subgraph(runner: QueryRunner, gds: GraphDataScience) -> No
 def test_project_subgraph(runner: QueryRunner, gds: GraphDataScience) -> None:
     from_G, _ = gds.graph.project(GRAPH_NAME, {"Node": {"properties": "x"}}, "*")
 
-    sub_G, result = gds.graph.project.subgraph("s", from_G, "n.x > 1", "*", concurrency=2)
+    sub_G, result = gds.graph.filter("s", from_G, "n.x > 1", "*", concurrency=2)
 
     assert sub_G.name() == "s"
     assert result["graphName"] == "s"

--- a/graphdatascience/tests/unit/test_graph_ops.py
+++ b/graphdatascience/tests/unit/test_graph_ops.py
@@ -74,12 +74,11 @@ def test_project_beta_subgraph(runner: CollectingQueryRunner, gds: GraphDataScie
 
 def test_project_subgraph(runner: CollectingQueryRunner, gds: GraphDataScience) -> None:
     from_G, _ = gds.graph.project("g", "*", "*")
-    gds.graph.project.subgraph("s", from_G, "n.x > 1", "*", concurrency=2)
+    gds.graph.filter("s", from_G, "n.x > 1", "*", concurrency=2)
 
     assert (
         runner.last_query()
-        == "CALL "
-        + "gds.graph.project.subgraph($graph_name, $from_graph_name, $node_filter, $relationship_filter, $config)"
+        == "CALL " + "gds.graph.filter($graph_name, $from_graph_name, $node_filter, $relationship_filter, $config)"
     )
     assert runner.last_params() == {
         "graph_name": "s",


### PR DESCRIPTION
The new endpoint was renamed before publishing, so we can do a simple rename
