### PR TITLE
KGE predict typo fix + running notebook back

### DIFF
--- a/examples/kge-predict-transe-pyg-train.ipynb
+++ b/examples/kge-predict-transe-pyg-train.ipynb
@@ -407,7 +407,7 @@
    "outputs": [],
    "source": [
     "model = train_model_with_pyg()\n",
-    "# The model can be loaded is it was trained before\n",
+    "# The model can be loaded if it was trained before\n",
     "# model = torch.load(\"./model_501.pt\")"
    ]
   },

--- a/scripts/run_notebooks
+++ b/scripts/run_notebooks
@@ -5,8 +5,7 @@ set -o nounset
 set -o pipefail
 
 for file in examples/*; do
-    # Temporarily skipping notebooks requiring next server version
-    if test -f "$file" && test "$file" != "examples/kge-predict-transe-pyg-train.ipynb"; then
+    if [ -f "$file" ]; then
         echo "Executing jupyter notebook $file"
         jupyter nbconvert --to notebook --inplace --execute --ExecutePreprocessor.kernel_name=python3 $file
         echo "Finished executing jupyter notebook $file"


### PR DESCRIPTION
After releasing GDS 2.5, the KGE predict functionality is available, which means we can take back running kge-predict jupyter notebook example.


Thank you for your contribution to the Graph Data Science Client project.

<!-- Please include a summary of the change, such as, which issue was fixed or feature was added. 
If relevant, link to the corresponding issue.
Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Before submitting this PR, please read [Contributing to the Neo4j Ecosystem](https://github.com/neo4j/graph-data-science-client/blob/main/CONTRIBUTING.md). 

Make sure:
- [ ] You signed the [Neo4j CLA](https://neo4j.com/developer/cla/#sign-cla) (Contributor License Agreement) so that we are allowed to ship your code in our library
- [ ] Your contribution is covered by tests

