### PR TITLE
Do not fail when `type` key is missing

### DIFF
--- a/examples/dev/aura-only-features.ipynb
+++ b/examples/dev/aura-only-features.ipynb
@@ -33,17 +33,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "\n",
     "# AuraDB data ingestion\n",
     "from neo4j import GraphDatabase\n",
     "from graphdatascience.query_runner.aura_db_arrow_query_runner import AuraDbConnectionInfo\n",
     "\n",
+    "# Aura environment\n",
+    "os.environ[\"AURA_ENV\"] = \"devstrawberry\"\n",
+    "\n",
     "# DB credentials\n",
-    "db_id_and_pw = (\"fnkssdcf\", \"\")\n",
+    "db_id_and_pw = (\"fd4de318\", \"\")\n",
     "db_connection_info = AuraDbConnectionInfo(\n",
-    "    f\"neo4j+ssc://{db_id_and_pw[0]}-envgdssync.databases.neo4j-dev.io\", (\"neo4j\", db_id_and_pw[1])\n",
+    "    f\"neo4j+s://{db_id_and_pw[0]}-{os.environ['AURA_ENV']}.databases.neo4j-dev.io\", (\"neo4j\", db_id_and_pw[1])\n",
     ")\n",
     "# start a Driver\n",
-    "driver = GraphDatabase.driver(db_connection_info.uri, auth=db_connection_info.auth)"
+    "driver = GraphDatabase.driver(db_connection_info.uri, auth=db_connection_info.auth)\n",
+    "\n",
+    "# try out our connection\n",
+    "with driver.session() as session:\n",
+    "    display(session.run(\"RETURN true AS success\").to_df())"
    ]
   },
   {
@@ -54,7 +63,7 @@
    "source": [
     "# Add some data\n",
     "with driver.session() as session:\n",
-    "    #     session.run(\"CREATE CONSTRAINT users FOR (u:User) REQUIRE u.id IS NODE KEY\")\n",
+    "    session.run(\"CREATE CONSTRAINT users FOR (u:User) REQUIRE u.id IS NODE KEY\")\n",
     "    session.run(\n",
     "        \"\"\"\n",
     "        UNWIND range(0, 999) AS i\n",
@@ -150,14 +159,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "\n",
     "# Initialise Aura API credentials\n",
     "CLIENT_ID = os.environ.get(\"CLIENT_ID\")\n",
-    "CLIENT_SECRET = os.environ.get(\"CLIENT_SECRET\")\n",
-    "\n",
-    "# Target our development environment, not production\n",
-    "os.environ[\"AURA_ENV\"] = \"envgdssync\""
+    "CLIENT_SECRET = os.environ.get(\"CLIENT_SECRET\")"
    ]
   },
   {

--- a/graphdatascience/aura_api.py
+++ b/graphdatascience/aura_api.py
@@ -71,7 +71,7 @@ class InstanceCreateDetails(InstanceDetails):
             password=json["password"],
             username=json["username"],
             connection_url=json["connection_url"],
-            type=json["type"],
+            type=json.get("type", ""),
             region=json["region"],
         )
 

--- a/graphdatascience/aura_api.py
+++ b/graphdatascience/aura_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import logging
 import os
 import time
@@ -54,26 +55,19 @@ class InstanceSpecificDetails(InstanceDetails):
 
 
 @dataclass(repr=True)
-class InstanceCreateDetails(InstanceDetails):
-    password: str
+class InstanceCreateDetails:
+    id: str
     username: str
+    password: str
     connection_url: str
-    type: str
-    region: str
 
     @classmethod
-    def fromJson(cls, json: dict[str, Any]) -> InstanceCreateDetails:
-        return cls(
-            id=json["id"],
-            name=json.get("name", ""),
-            tenant_id=json["tenant_id"],
-            cloud_provider=json["cloud_provider"],
-            password=json["password"],
-            username=json["username"],
-            connection_url=json["connection_url"],
-            type=json.get("type", ""),
-            region=json["region"],
-        )
+    def from_json(cls, json: dict[str, Any]) -> InstanceCreateDetails:
+        fields = dataclasses.fields(cls)
+        if any(f.name not in json for f in fields):
+            raise RuntimeError(f"Missing required field. Expected `{[f.name for f in fields]}` but got `{json}`")
+
+        return cls(**{f.name: json[f.name] for f in fields})
 
 
 class AuraApi:
@@ -134,7 +128,7 @@ class AuraApi:
             print(response.json())
             raise e
 
-        return InstanceCreateDetails.fromJson(response.json()["data"])
+        return InstanceCreateDetails.from_json(response.json()["data"])
 
     def delete_instance(self, instance_id: str) -> Optional[InstanceSpecificDetails]:
         response = req.delete(

--- a/graphdatascience/tests/unit/test_aura_api.py
+++ b/graphdatascience/tests/unit/test_aura_api.py
@@ -5,7 +5,11 @@ from _pytest.logging import LogCaptureFixture
 from requests import HTTPError
 from requests_mock import Mocker
 
-from graphdatascience.aura_api import AuraApi, InstanceSpecificDetails
+from graphdatascience.aura_api import (
+    AuraApi,
+    InstanceCreateDetails,
+    InstanceSpecificDetails,
+)
 
 
 def test_delete_instance(requests_mock: Mocker) -> None:
@@ -303,3 +307,13 @@ def test_extract_id() -> None:
 def test_failing_extract_id(uri: str) -> None:
     with pytest.raises(RuntimeError, match="Could not parse the uri"):
         AuraApi.extract_id(uri)
+
+
+def test_parse_create_details():
+    InstanceCreateDetails.from_json({"id": "1", "username": "mats", "password": "1234", "connection_url": "url"})
+    with pytest.raises(RuntimeError, match="Missing required field"):
+        InstanceCreateDetails.from_json({"id": "1", "username": "mats", "password": "1234"})
+    # too much is fine
+    InstanceCreateDetails.from_json(
+        {"id": "1", "username": "mats", "password": "1234", "connection_url": "url", "region": "fooo"}
+    )

--- a/graphdatascience/tests/unit/test_aura_api.py
+++ b/graphdatascience/tests/unit/test_aura_api.py
@@ -309,7 +309,7 @@ def test_failing_extract_id(uri: str) -> None:
         AuraApi.extract_id(uri)
 
 
-def test_parse_create_details():
+def test_parse_create_details() -> None:
     InstanceCreateDetails.from_json({"id": "1", "username": "mats", "password": "1234", "connection_url": "url"})
     with pytest.raises(RuntimeError, match="Missing required field"):
         InstanceCreateDetails.from_json({"id": "1", "username": "mats", "password": "1234"})

--- a/graphdatascience/tests/unit/test_aura_sessions.py
+++ b/graphdatascience/tests/unit/test_aura_sessions.py
@@ -35,26 +35,21 @@ class FakeAuraApi(AuraApi):
     def create_instance(self, name: str, cloud_provider: str, region: str) -> InstanceCreateDetails:
         create_details = InstanceCreateDetails(
             id=f"ffff{self.id_counter}",
-            name=name,
-            tenant_id="tenant_id",
-            cloud_provider=cloud_provider,
             username="neo4j",
             password="fake-pw",
             connection_url="fake-url",
-            type="",
-            region=region,
         )
 
         specific_details = InstanceSpecificDetails(
             id=create_details.id,
-            name=create_details.name,
-            tenant_id=create_details.tenant_id,
-            cloud_provider=create_details.cloud_provider,
             status="creating",
             connection_url="fake-url",
             memory="",
             type="",
             region=region,
+            name=name,
+            tenant_id=self._tenant_id,
+            cloud_provider=cloud_provider,
         )
 
         self.id_counter += 1


### PR DESCRIPTION
It can happen that this key is missing from the response body. It doesn't matter so much for us when this happens during `create` so we can be soft about it.