### PR TITLE
Allow gds.graph.drop by graph name

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@
 ## Improvements
 
 * Expose user facing custom types so that they can be directly imported from `graphdatascience`.
+* Allow dropping graphs through `gds.graph.drop` by name and not only based on `Graph` objects.
 
 
 ## Other changes

--- a/graphdatascience/graph/graph_proc_runner.py
+++ b/graphdatascience/graph/graph_proc_runner.py
@@ -294,18 +294,20 @@ class GraphProcRunner(UncallableNamespace, IllegalAttrChecker):
         self._namespace += ".ogbl"
         return OGBLLoader(self._query_runner, self._namespace, self._server_version)
 
-    @graph_type_check
     def drop(
         self,
-        G: Graph,
+        graph: Union[Graph, str],
         failIfMissing: bool = False,
         dbName: str = "",
         username: Optional[str] = None,
     ) -> Optional["Series[Any]"]:
         self._namespace += ".drop"
 
+        if isinstance(graph, Graph):
+            graph = graph.name()
+
         params = CallParameters(
-            graph_name=G.name(),
+            graph_name=graph,
             fail_if_missing=failIfMissing,
             db_name=dbName,
         )

--- a/graphdatascience/tests/integration/conftest.py
+++ b/graphdatascience/tests/integration/conftest.py
@@ -110,7 +110,7 @@ def clean_up(gds: GraphDataScience) -> Generator[None, None, None]:
 
     res = gds.graph.list()
     for graph_name in res["graphName"]:
-        gds.graph.get(graph_name).drop(failIfMissing=True)
+        gds.graph.drop(graph_name, failIfMissing=True)
 
     res = gds.pipeline.list() if gds.server_version() >= ServerVersion(2, 5, 0) else gds.beta.pipeline.list()
     for pipeline_name in res["pipelineName"]:

--- a/graphdatascience/tests/integration/test_edge_embedding_model.py
+++ b/graphdatascience/tests/integration/test_edge_embedding_model.py
@@ -4,7 +4,6 @@ import pytest
 
 from graphdatascience.graph_data_science import GraphDataScience
 from graphdatascience.model.simple_rel_embedding_model import SimpleRelEmbeddingModel
-from graphdatascience.query_runner.neo4j_query_runner import Neo4jQueryRunner
 from graphdatascience.server_version.server_version import ServerVersion
 
 GRAPH_NAME = "g"
@@ -21,9 +20,9 @@ CONCURRENCY = 2
 
 
 @pytest.fixture(autouse=True)
-def run_around_tests(runner: Neo4jQueryRunner) -> Generator[None, None, None]:
+def run_around_tests(gds: GraphDataScience) -> Generator[None, None, None]:
     # Runs before each test
-    runner.run_cypher(
+    gds.run_cypher(
         """
         CREATE
         (a: Node {x: 1, y: 2, z: [42.1, 131.0, 12.99]}),
@@ -39,8 +38,8 @@ def run_around_tests(runner: Neo4jQueryRunner) -> Generator[None, None, None]:
     yield  # Test runs here
 
     # Runs after each test
-    runner.run_cypher("MATCH (n) DETACH DELETE n")
-    runner.run_cypher(f"CALL gds.graph.drop('{GRAPH_NAME}', false)")
+    gds.run_cypher("MATCH (n) DETACH DELETE n")
+    gds.graph.drop(GRAPH_NAME)
 
 
 @pytest.fixture

--- a/graphdatascience/tests/integration/test_error_handling.py
+++ b/graphdatascience/tests/integration/test_error_handling.py
@@ -3,15 +3,14 @@ from typing import Generator
 import pytest
 
 from graphdatascience import GraphDataScience
-from graphdatascience.query_runner.neo4j_query_runner import Neo4jQueryRunner
 
 GRAPH_NAME = "g"
 
 
 @pytest.fixture(autouse=True)
-def run_around_tests(runner: Neo4jQueryRunner) -> Generator[None, None, None]:
+def run_around_tests(gds: GraphDataScience) -> Generator[None, None, None]:
     # Runs before each test
-    runner.run_cypher(
+    gds.run_cypher(
         """
         CREATE
         (a: Node),
@@ -26,8 +25,8 @@ def run_around_tests(runner: Neo4jQueryRunner) -> Generator[None, None, None]:
     yield  # Test runs here
 
     # Runs after each test
-    runner.run_cypher("MATCH (n) DETACH DELETE n")
-    runner.run_cypher(f"CALL gds.graph.drop('{GRAPH_NAME}', false)")
+    gds.run_cypher("MATCH (n) DETACH DELETE n")
+    gds.graph.drop(GRAPH_NAME)
 
 
 def test_bogus_algo(gds: GraphDataScience) -> None:

--- a/graphdatascience/tests/integration/test_graph_construct.py
+++ b/graphdatascience/tests/integration/test_graph_construct.py
@@ -6,7 +6,6 @@ from pandas import DataFrame
 
 from graphdatascience.graph_data_science import GraphDataScience
 from graphdatascience.query_runner.arrow_query_runner import ArrowQueryRunner
-from graphdatascience.query_runner.neo4j_query_runner import Neo4jQueryRunner
 from graphdatascience.server_version.server_version import ServerVersion
 from graphdatascience.tests.integration.conftest import AUTH, URI
 
@@ -14,9 +13,9 @@ GRAPH_NAME = "g"
 
 
 @pytest.fixture(autouse=True)
-def run_around_tests(runner: Neo4jQueryRunner) -> Generator[None, None, None]:
+def run_around_tests(gds: GraphDataScience) -> Generator[None, None, None]:
     # Runs before each test
-    runner.run_cypher(
+    gds.run_cypher(
         """
         CREATE
         (a: Node {x: 1, y: 2, z: [42]}),
@@ -32,8 +31,8 @@ def run_around_tests(runner: Neo4jQueryRunner) -> Generator[None, None, None]:
     yield  # Test runs here
 
     # Runs after each test
-    runner.run_cypher("MATCH (n) DETACH DELETE n")
-    runner.run_cypher(f"CALL gds.graph.drop('{GRAPH_NAME}', false) YIELD graphName")
+    gds.run_cypher("MATCH (n) DETACH DELETE n")
+    gds.graph.drop(GRAPH_NAME)
 
 
 @pytest.mark.filterwarnings("ignore: GDS Enterprise users can use Apache Arrow")

--- a/graphdatascience/tests/integration/test_simple_algo.py
+++ b/graphdatascience/tests/integration/test_simple_algo.py
@@ -9,9 +9,9 @@ GRAPH_NAME = "g"
 
 
 @fixture(autouse=True)
-def run_around_tests(runner: Neo4jQueryRunner) -> Generator[None, None, None]:
+def run_around_tests(gds: GraphDataScience) -> Generator[None, None, None]:
     # Runs before each test
-    runner.run_cypher(
+    gds.run_cypher(
         """
         CREATE
         (a: Node),
@@ -26,11 +26,11 @@ def run_around_tests(runner: Neo4jQueryRunner) -> Generator[None, None, None]:
     yield  # Test runs here
 
     # Runs after each test
-    runner.run_cypher("MATCH (n) DETACH DELETE n")
-    runner.run_cypher(f"CALL gds.graph.drop('{GRAPH_NAME}')")
+    gds.run_cypher("MATCH (n) DETACH DELETE n")
+    gds.graph.drop(GRAPH_NAME)
 
 
-def test_pageRank_mutate(runner: Neo4jQueryRunner, gds: GraphDataScience) -> None:
+def test_pageRank_mutate(gds: GraphDataScience) -> None:
     G, _ = gds.graph.project(GRAPH_NAME, "*", "*")
 
     result = gds.pageRank.mutate(G, mutateProperty="rank", dampingFactor=0.2, tolerance=0.3)

--- a/graphdatascience/tests/integration/test_single_mode_algos.py
+++ b/graphdatascience/tests/integration/test_single_mode_algos.py
@@ -4,16 +4,15 @@ import pytest
 from pytest import fixture
 
 from graphdatascience.graph_data_science import GraphDataScience
-from graphdatascience.query_runner.neo4j_query_runner import Neo4jQueryRunner
 from graphdatascience.server_version.server_version import ServerVersion
 
 GRAPH_NAME = "g"
 
 
 @fixture(autouse=True)
-def run_around_tests(runner: Neo4jQueryRunner) -> Generator[None, None, None]:
+def run_around_tests(gds: GraphDataScience) -> Generator[None, None, None]:
     # Runs before each test
-    runner.run_cypher(
+    gds.run_cypher(
         """
         CREATE
         (a: Node),
@@ -28,8 +27,8 @@ def run_around_tests(runner: Neo4jQueryRunner) -> Generator[None, None, None]:
     yield  # Test runs here
 
     # Runs after each test
-    runner.run_cypher("MATCH (n) DETACH DELETE n")
-    runner.run_cypher(f"CALL gds.graph.drop('{GRAPH_NAME}')")
+    gds.run_cypher("MATCH (n) DETACH DELETE n")
+    gds.graph.drop(GRAPH_NAME)
 
 
 @pytest.mark.compatible_with(min_inclusive=ServerVersion(2, 5, 0))


### PR DESCRIPTION
Before you had to check gds.graph.exists upfront, as you cannot get a Graph object if the graph does not exists.
This makes it a lot shorter and usage of `failIfMissing=False` parameter actually useful from the client.