### PR TITLE
Add __init__ to ref docs

### DIFF
--- a/doc/sphinx/source/graphdatascience.rst
+++ b/doc/sphinx/source/graphdatascience.rst
@@ -4,4 +4,3 @@ GraphDataScience
 .. autoclass:: graphdatascience.GraphDataScience
     :members:
     :inherited-members:
-    :exclude-members: __init__


### PR DESCRIPTION
Previously assumed it would be added twice without this exclusion (https://github.com/neo4j/graph-data-science-client/pull/383#discussion_r1209258179).
