### PR TITLE
Handle empty memory on GET instance details

### DIFF
--- a/graphdatascience/session/aura_api_responses.py
+++ b/graphdatascience/session/aura_api_responses.py
@@ -82,7 +82,7 @@ class InstanceSpecificDetails(InstanceDetails):
             cloud_provider=json["cloud_provider"],
             status=json["status"],
             connection_url=json.get("connection_url", ""),
-            memory=SessionMemoryValue.fromApiResponse(json.get("memory", "")),
+            memory=SessionMemoryValue.fromInstanceSize(json.get("memory")),
             type=json["type"],
             region=json["region"],
         )

--- a/graphdatascience/session/aurads_sessions.py
+++ b/graphdatascience/session/aurads_sessions.py
@@ -59,8 +59,8 @@ class AuraDsSessions:
 
         if existing_session:
             session_id = existing_session.id
-            # "0MB" or "" is AuraAPI default value for memory if none can be retrieved
-            if existing_session.memory.value == "0MB" or existing_session.memory == SESSION_MEMORY_VALUE_UNKNOWN:
+            # AuraAPI default value for memory if none can be retrieved
+            if existing_session.memory == SESSION_MEMORY_VALUE_UNKNOWN:
                 self._logger.debug(
                     f"Reusing existing session with id `{session_id}` as size for session is unknown during creation."
                 )

--- a/graphdatascience/session/session_sizes.py
+++ b/graphdatascience/session/session_sizes.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import Enum
-from typing import List
+from typing import List, Optional
 
 
 @dataclass(frozen=True)
@@ -11,7 +13,7 @@ class SessionMemoryValue:
         return self.value
 
     @staticmethod
-    def fromApiResponse(value: str) -> "SessionMemoryValue":
+    def fromApiResponse(value: str) -> SessionMemoryValue:
         """
         Converts the string value from an API response to a SessionMemory enumeration value.
 
@@ -26,6 +28,16 @@ class SessionMemoryValue:
             raise ValueError("memory configuration cannot be empty")
 
         return SessionMemoryValue(value.replace("Gi", "GB"))
+
+    @staticmethod
+    def fromInstanceSize(value: Optional[str]) -> SessionMemoryValue:
+        if not value:
+            return SESSION_MEMORY_VALUE_UNKNOWN
+
+        return SessionMemoryValue(value.replace("Gi", "GB"))
+
+
+SESSION_MEMORY_VALUE_UNKNOWN = SessionMemoryValue("")
 
 
 class SessionMemory(Enum):

--- a/graphdatascience/tests/unit/test_aura_api.py
+++ b/graphdatascience/tests/unit/test_aura_api.py
@@ -18,6 +18,7 @@ from graphdatascience.session.aura_api_responses import (
     TimeParser,
     WaitResult,
 )
+from graphdatascience.session.session_sizes import SESSION_MEMORY_VALUE_UNKNOWN
 
 
 def test_create_session(requests_mock: Mocker) -> None:
@@ -438,7 +439,7 @@ def test_list_instance_missing_memory_field(requests_mock: Mocker) -> None:
                 "status": "creating",
                 "tenant_id": "046046d1-6996-53e4-8880-5b822766e1f9",
                 "type": "enterprise-ds",
-                "memory": "16Gi",
+                "memory": "",
             }
         },
     )
@@ -446,7 +447,7 @@ def test_list_instance_missing_memory_field(requests_mock: Mocker) -> None:
     result = api.list_instance("id0")
 
     assert result and result.id == "a10fb995"
-    assert result.memory == SessionMemory.m_16GB.value
+    assert result.memory == SESSION_MEMORY_VALUE_UNKNOWN
 
 
 def test_list_missing_instance(requests_mock: Mocker) -> None:


### PR DESCRIPTION
The endpoint does not return the actual memory config during creation
