### PR TITLE
Pass dbid only when needed to aura-api

### DIFF
--- a/graphdatascience/session/aura_api.py
+++ b/graphdatascience/session/aura_api.py
@@ -84,9 +84,7 @@ class AuraApi:
             "instanceId": dbid,
         }
 
-        response = self._request_session.get(
-            f"{self._base_uri}/v1beta5/data-science/sessions", params=params
-        )
+        response = self._request_session.get(f"{self._base_uri}/v1beta5/data-science/sessions", params=params)
 
         self._check_resp(response)
 

--- a/graphdatascience/session/aura_api.py
+++ b/graphdatascience/session/aura_api.py
@@ -81,13 +81,11 @@ class AuraApi:
     def list_sessions(self, dbid: Optional[str] = None) -> List[SessionDetails]:
         params = {
             "tenantId": self._tenant_id,
+            "instanceId": dbid,
         }
 
-        if dbid:
-            params["instanceId"] = dbid
-
         response = self._request_session.get(
-            f"{self._base_uri}/v1beta5/data-science/sessions?instanceId={dbid}", params=params
+            f"{self._base_uri}/v1beta5/data-science/sessions", params=params
         )
 
         self._check_resp(response)


### PR DESCRIPTION
latest changes in Aura allow to not always send the instanceId along.
Also the uniqenuess constraint is checked inside Aura now.
