### PR TITLE
Avoid reading env in AuraAPI constructor

### DIFF
--- a/graphdatascience/session/aura_api.py
+++ b/graphdatascience/session/aura_api.py
@@ -32,6 +32,8 @@ class AuraApiError(Exception):
 
 class AuraApi:
 
+    API_VERSION = "v1beta5"
+
     def __init__(
         self, client_id: str, client_secret: str, tenant_id: Optional[str] = None, aura_env: Optional[str] = None
     ) -> None:
@@ -68,7 +70,7 @@ class AuraApi:
 
     def create_session(self, name: str, dbid: str, pwd: str, memory: SessionMemoryValue) -> SessionDetails:
         response = self._request_session.post(
-            f"{self._base_uri}/v1beta5/data-science/sessions",
+            f"{self._base_uri}/{AuraApi.API_VERSION}/data-science/sessions",
             json={"name": name, "instance_id": dbid, "password": pwd, "memory": memory.value},
         )
 
@@ -77,7 +79,9 @@ class AuraApi:
         return SessionDetails.fromJson(response.json()["data"])
 
     def list_session(self, session_id: str) -> Optional[SessionDetails]:
-        response = self._request_session.get(f"{self._base_uri}/v1beta5/data-science/sessions/{session_id}")
+        response = self._request_session.get(
+            f"{self._base_uri}/{AuraApi.API_VERSION}/data-science/sessions/{session_id}"
+        )
 
         self._check_resp(response)
 
@@ -89,7 +93,9 @@ class AuraApi:
             "instanceId": dbid,
         }
 
-        response = self._request_session.get(f"{self._base_uri}/v1beta5/data-science/sessions", params=params)
+        response = self._request_session.get(
+            f"{self._base_uri}/{AuraApi.API_VERSION}/data-science/sessions", params=params
+        )
 
         self._check_resp(response)
 
@@ -123,7 +129,7 @@ class AuraApi:
 
     def delete_session(self, session_id: str) -> bool:
         response = self._request_session.delete(
-            f"{self._base_uri}/v1beta5/data-science/sessions/{session_id}",
+            f"{self._base_uri}/{AuraApi.API_VERSION}/data-science/sessions/{session_id}",
         )
 
         self._check_endpoint_expiry(response)

--- a/graphdatascience/session/aura_api.py
+++ b/graphdatascience/session/aura_api.py
@@ -46,8 +46,8 @@ class AuraApi:
         self._tenant_id = tenant_id if tenant_id else self._get_tenant_id()
         self._tenant_details: Optional[TenantDetails] = None
 
-    @staticmethod
-    def create(client_id: str, client_secret: str, tenant_id: Optional[str] = None) -> AuraApi:
+    @classmethod
+    def create(cls, client_id: str, client_secret: str, tenant_id: Optional[str] = None) -> AuraApi:
         aura_env = os.environ.get("AURA_ENV")
 
         if not aura_env or aura_env == "production":
@@ -57,7 +57,7 @@ class AuraApi:
         else:
             base_uri = f"https://api-{aura_env}.neo4j-dev.io"
 
-        return AuraApi(base_uri, client_id, client_secret, tenant_id)
+        return cls(base_uri, client_id, client_secret, tenant_id)
 
     @staticmethod
     def extract_id(uri: str) -> str:

--- a/graphdatascience/session/aura_api.py
+++ b/graphdatascience/session/aura_api.py
@@ -33,19 +33,6 @@ class AuraApiError(Exception):
 
 class AuraApi:
 
-    @staticmethod
-    def create(client_id: str, client_secret: str, tenant_id: Optional[str] = None) -> AuraApi:
-        aura_env = os.environ.get("AURA_ENV")
-
-        if not aura_env or aura_env == "production":
-            base_uri = "https://api.neo4j.io"
-        elif aura_env == "staging":
-            base_uri = "https://api-staging.neo4j.io"
-        else:
-            base_uri = f"https://api-{aura_env}.neo4j-dev.io"
-
-        return AuraApi(base_uri, client_id, client_secret, tenant_id)
-
     def __init__(self, base_uri: str, client_id: str, client_secret: str, tenant_id: Optional[str] = None) -> None:
         self._base_uri = base_uri
 
@@ -58,6 +45,19 @@ class AuraApi:
 
         self._tenant_id = tenant_id if tenant_id else self._get_tenant_id()
         self._tenant_details: Optional[TenantDetails] = None
+
+    @staticmethod
+    def create(client_id: str, client_secret: str, tenant_id: Optional[str] = None) -> AuraApi:
+        aura_env = os.environ.get("AURA_ENV")
+
+        if not aura_env or aura_env == "production":
+            base_uri = "https://api.neo4j.io"
+        elif aura_env == "staging":
+            base_uri = "https://api-staging.neo4j.io"
+        else:
+            base_uri = f"https://api-{aura_env}.neo4j-dev.io"
+
+        return AuraApi(base_uri, client_id, client_secret, tenant_id)
 
     @staticmethod
     def extract_id(uri: str) -> str:

--- a/graphdatascience/session/aura_api.py
+++ b/graphdatascience/session/aura_api.py
@@ -32,15 +32,22 @@ class AuraApiError(Exception):
 
 
 class AuraApi:
-    def __init__(self, client_id: str, client_secret: str, tenant_id: Optional[str] = None) -> None:
-        self._aura_env = os.environ.get("AURA_ENV")
 
-        if not self._aura_env or self._aura_env == "production":
-            self._base_uri = "https://api.neo4j.io"
-        elif self._aura_env == "staging":
-            self._base_uri = "https://api-staging.neo4j.io"
+    @staticmethod
+    def create(client_id: str, client_secret: str, tenant_id: Optional[str] = None) -> AuraApi:
+        aura_env = os.environ.get("AURA_ENV")
+
+        if not aura_env or aura_env == "production":
+            base_uri = "https://api.neo4j.io"
+        elif aura_env == "staging":
+            base_uri = "https://api-staging.neo4j.io"
         else:
-            self._base_uri = f"https://api-{self._aura_env}.neo4j-dev.io"
+            base_uri = f"https://api-{aura_env}.neo4j-dev.io"
+
+        return AuraApi(base_uri, client_id, client_secret, tenant_id)
+
+    def __init__(self, base_uri: str, client_id: str, client_secret: str, tenant_id: Optional[str] = None) -> None:
+        self._base_uri = base_uri
 
         self._auth = AuraApi.Auth(oauth_url=f"{self._base_uri}/oauth/token", credentials=(client_id, client_secret))
         self._logger = logging.getLogger()

--- a/graphdatascience/session/gds_sessions.py
+++ b/graphdatascience/session/gds_sessions.py
@@ -42,7 +42,13 @@ class GdsSessions:
         Args:
             api_credentials (AuraAPICredentials): The Aura API credentials used for establishing a connection.
         """
-        aura_api = AuraApi.create(api_credentials.client_id, api_credentials.client_secret, api_credentials.tenant_id)
+        aura_env = os.environ.get("AURA_ENV")
+        aura_api = AuraApi(
+            aura_env=aura_env,
+            client_id=api_credentials.client_id,
+            client_secret=api_credentials.client_secret,
+            tenant_id=api_credentials.tenant_id,
+        )
         session_type_flag = os.environ.get("USE_DEDICATED_SESSIONS", "true").lower() == "true"
         self._impl: Union[DedicatedSessions, AuraDsSessions] = (
             DedicatedSessions(aura_api) if session_type_flag else AuraDsSessions(aura_api)

--- a/graphdatascience/session/gds_sessions.py
+++ b/graphdatascience/session/gds_sessions.py
@@ -42,7 +42,7 @@ class GdsSessions:
         Args:
             api_credentials (AuraAPICredentials): The Aura API credentials used for establishing a connection.
         """
-        aura_api = AuraApi(api_credentials.client_id, api_credentials.client_secret, api_credentials.tenant_id)
+        aura_api = AuraApi.create(api_credentials.client_id, api_credentials.client_secret, api_credentials.tenant_id)
         session_type_flag = os.environ.get("USE_DEDICATED_SESSIONS", "true").lower() == "true"
         self._impl: Union[DedicatedSessions, AuraDsSessions] = (
             DedicatedSessions(aura_api) if session_type_flag else AuraDsSessions(aura_api)

--- a/graphdatascience/tests/unit/test_aura_api.py
+++ b/graphdatascience/tests/unit/test_aura_api.py
@@ -27,6 +27,12 @@ def mock_auth_token(requests_mock: Mocker) -> None:
     )
 
 
+def test_base_uri_from_env() -> None:
+    assert AuraApi.base_uri("dev") == "https://api-dev.neo4j-dev.io"
+    assert AuraApi.base_uri(None) == "https://api.neo4j.io"
+    assert AuraApi.base_uri("staging") == "https://api-staging.neo4j.io"
+
+
 def test_create_session(requests_mock: Mocker) -> None:
     api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
 

--- a/graphdatascience/tests/unit/test_aura_api.py
+++ b/graphdatascience/tests/unit/test_aura_api.py
@@ -28,7 +28,7 @@ def mock_auth_token(requests_mock: Mocker) -> None:
 
 
 def test_create_session(requests_mock: Mocker) -> None:
-    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
 
     mock_auth_token(requests_mock)
 
@@ -68,7 +68,7 @@ def test_create_session(requests_mock: Mocker) -> None:
 
 def test_list_session(requests_mock: Mocker) -> None:
 
-    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
 
     mock_auth_token(requests_mock)
 
@@ -108,7 +108,7 @@ def test_list_session(requests_mock: Mocker) -> None:
 
 
 def test_list_sessions(requests_mock: Mocker) -> None:
-    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
     mock_auth_token(requests_mock)
 
     requests_mock.get(
@@ -176,7 +176,7 @@ def test_list_sessions(requests_mock: Mocker) -> None:
 
 
 def test_list_sessions_with_db_id(requests_mock: Mocker) -> None:
-    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
     mock_auth_token(requests_mock)
 
     requests_mock.get(
@@ -244,7 +244,7 @@ def test_list_sessions_with_db_id(requests_mock: Mocker) -> None:
 
 
 def test_delete_session(requests_mock: Mocker) -> None:
-    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
 
     mock_auth_token(requests_mock)
     requests_mock.delete(
@@ -256,7 +256,7 @@ def test_delete_session(requests_mock: Mocker) -> None:
 
 
 def test_delete_missing_session(requests_mock: Mocker) -> None:
-    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
 
     mock_auth_token(requests_mock)
     requests_mock.delete(
@@ -284,7 +284,7 @@ def test_multiple_tenants(requests_mock: Mocker) -> None:
         RuntimeError,
         match="This account has access to multiple tenants: `{'tenant1': 'Production', 'tenant2': 'Development'}`",
     ):
-        AuraApi(client_id="", client_secret="")
+        AuraApi.create(client_id="", client_secret="")
 
 
 def test_dont_wait_forever_for_session(requests_mock: Mocker, caplog: LogCaptureFixture) -> None:
@@ -307,7 +307,7 @@ def test_dont_wait_forever_for_session(requests_mock: Mocker, caplog: LogCapture
         },
     )
 
-    api = AuraApi("", "", tenant_id="some-tenant")
+    api = AuraApi.create("", "", tenant_id="some-tenant")
 
     with caplog.at_level(logging.DEBUG):
         assert (
@@ -338,13 +338,13 @@ def test_wait_for_session_running(requests_mock: Mocker) -> None:
         },
     )
 
-    api = AuraApi("", "", tenant_id="some-tenant")
+    api = AuraApi.create("", "", tenant_id="some-tenant")
 
     assert api.wait_for_session_running("id0") == WaitResult.from_connection_url("neo4j+s://foo.bar")
 
 
 def test_delete_instance(requests_mock: Mocker) -> None:
-    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
 
     mock_auth_token(requests_mock)
 
@@ -382,7 +382,7 @@ def test_delete_instance(requests_mock: Mocker) -> None:
 
 
 def test_delete_already_deleting_instance(requests_mock: Mocker) -> None:
-    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
 
     mock_auth_token(requests_mock)
     requests_mock.delete(
@@ -397,7 +397,7 @@ def test_delete_already_deleting_instance(requests_mock: Mocker) -> None:
 
 
 def test_delete_that_fails(requests_mock: Mocker) -> None:
-    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
 
     mock_auth_token(requests_mock)
     requests_mock.delete(
@@ -412,7 +412,7 @@ def test_delete_that_fails(requests_mock: Mocker) -> None:
 
 
 def test_create_instance(requests_mock: Mocker) -> None:
-    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
 
     mock_auth_token(requests_mock)
 
@@ -452,7 +452,7 @@ def test_create_instance(requests_mock: Mocker) -> None:
 
 
 def test_warn_about_expirying_endpoint(requests_mock: Mocker) -> None:
-    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
 
     mock_auth_token(requests_mock)
     requests_mock.delete(
@@ -466,7 +466,7 @@ def test_warn_about_expirying_endpoint(requests_mock: Mocker) -> None:
 
 
 def test_auth_token(requests_mock: Mocker) -> None:
-    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
 
     requests_mock.post(
         "https://api.neo4j.io/oauth/token",
@@ -484,7 +484,7 @@ def test_auth_token(requests_mock: Mocker) -> None:
 
 
 def test_auth_token_reused(requests_mock: Mocker) -> None:
-    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
 
     requests_mock.post(
         "https://api.neo4j.io/oauth/token",
@@ -503,7 +503,7 @@ def test_auth_token_reused(requests_mock: Mocker) -> None:
 
 
 def test_auth_token_use_short_token(requests_mock: Mocker) -> None:
-    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
 
     requests_mock.post(
         "https://api.neo4j.io/oauth/token",
@@ -522,7 +522,7 @@ def test_derive_tenant(requests_mock: Mocker) -> None:
         json={"data": [{"id": "6981ace7-efe8-4f5c-b7c5-267b5162ce91", "name": "Production"}]},
     )
 
-    AuraApi(client_id="", client_secret="")
+    AuraApi.create(client_id="", client_secret="")
 
 
 def test_raise_on_missing_tenant(requests_mock: Mocker) -> None:
@@ -540,11 +540,11 @@ def test_raise_on_missing_tenant(requests_mock: Mocker) -> None:
     )
 
     with pytest.raises(RuntimeError, match="This account has access to multiple tenants"):
-        AuraApi(client_id="", client_secret="")
+        AuraApi.create(client_id="", client_secret="")
 
 
 def test_list_instance(requests_mock: Mocker) -> None:
-    api = AuraApi(client_id="", client_secret="", tenant_id="YOUR_TENANT_ID")
+    api = AuraApi.create(client_id="", client_secret="", tenant_id="YOUR_TENANT_ID")
 
     mock_auth_token(requests_mock)
     requests_mock.get(
@@ -573,7 +573,7 @@ def test_list_instance(requests_mock: Mocker) -> None:
 
 
 def test_list_instance_missing_memory_field(requests_mock: Mocker) -> None:
-    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
 
     mock_auth_token(requests_mock)
     requests_mock.get(
@@ -600,7 +600,7 @@ def test_list_instance_missing_memory_field(requests_mock: Mocker) -> None:
 
 
 def test_list_missing_instance(requests_mock: Mocker) -> None:
-    api = AuraApi("", "", tenant_id="some-tenant")
+    api = AuraApi.create("", "", tenant_id="some-tenant")
 
     mock_auth_token(requests_mock)
 
@@ -633,7 +633,7 @@ def test_dont_wait_forever(requests_mock: Mocker, caplog: LogCaptureFixture) -> 
         },
     )
 
-    api = AuraApi("", "", tenant_id="some-tenant")
+    api = AuraApi.create("", "", tenant_id="some-tenant")
 
     with caplog.at_level(logging.DEBUG):
         assert (
@@ -663,7 +663,7 @@ def test_wait_for_instance_running(requests_mock: Mocker) -> None:
         },
     )
 
-    api = AuraApi("", "", tenant_id="some-tenant")
+    api = AuraApi.create("", "", tenant_id="some-tenant")
 
     assert api.wait_for_instance_running("id0") == WaitResult.from_connection_url("foo.bar")
 
@@ -703,7 +703,7 @@ def test_wait_for_instance_deleting(requests_mock: Mocker) -> None:
         },
     )
 
-    api = AuraApi("", "", tenant_id="some-tenant")
+    api = AuraApi.create("", "", tenant_id="some-tenant")
 
     assert api.wait_for_instance_running("id0") == WaitResult.from_error("Instance is being deleted")
     assert api.wait_for_instance_running("id1") == WaitResult.from_error("Instance is being deleted")
@@ -716,7 +716,7 @@ def test_estimate_size(requests_mock: Mocker) -> None:
         json={"data": {"did_exceed_maximum": True, "min_required_memory": "307GB", "recommended_size": "96GB"}},
     )
 
-    api = AuraApi("", "", tenant_id="some-tenant")
+    api = AuraApi.create("", "", tenant_id="some-tenant")
     assert api.estimate_size(100, 10, [AlgorithmCategory.NODE_EMBEDDING]) == EstimationDetails("307GB", "96GB", True)
 
 

--- a/graphdatascience/tests/unit/test_aura_api.py
+++ b/graphdatascience/tests/unit/test_aura_api.py
@@ -28,7 +28,7 @@ def mock_auth_token(requests_mock: Mocker) -> None:
 
 
 def test_create_session(requests_mock: Mocker) -> None:
-    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
 
     mock_auth_token(requests_mock)
 
@@ -68,7 +68,7 @@ def test_create_session(requests_mock: Mocker) -> None:
 
 def test_list_session(requests_mock: Mocker) -> None:
 
-    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
 
     mock_auth_token(requests_mock)
 
@@ -108,7 +108,7 @@ def test_list_session(requests_mock: Mocker) -> None:
 
 
 def test_list_sessions(requests_mock: Mocker) -> None:
-    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
     mock_auth_token(requests_mock)
 
     requests_mock.get(
@@ -176,7 +176,7 @@ def test_list_sessions(requests_mock: Mocker) -> None:
 
 
 def test_list_sessions_with_db_id(requests_mock: Mocker) -> None:
-    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
     mock_auth_token(requests_mock)
 
     requests_mock.get(
@@ -244,7 +244,7 @@ def test_list_sessions_with_db_id(requests_mock: Mocker) -> None:
 
 
 def test_delete_session(requests_mock: Mocker) -> None:
-    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
 
     mock_auth_token(requests_mock)
     requests_mock.delete(
@@ -256,7 +256,7 @@ def test_delete_session(requests_mock: Mocker) -> None:
 
 
 def test_delete_missing_session(requests_mock: Mocker) -> None:
-    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
 
     mock_auth_token(requests_mock)
     requests_mock.delete(
@@ -284,7 +284,7 @@ def test_multiple_tenants(requests_mock: Mocker) -> None:
         RuntimeError,
         match="This account has access to multiple tenants: `{'tenant1': 'Production', 'tenant2': 'Development'}`",
     ):
-        AuraApi.create(client_id="", client_secret="")
+        AuraApi(client_id="", client_secret="")
 
 
 def test_dont_wait_forever_for_session(requests_mock: Mocker, caplog: LogCaptureFixture) -> None:
@@ -307,7 +307,7 @@ def test_dont_wait_forever_for_session(requests_mock: Mocker, caplog: LogCapture
         },
     )
 
-    api = AuraApi.create("", "", tenant_id="some-tenant")
+    api = AuraApi("", "", tenant_id="some-tenant")
 
     with caplog.at_level(logging.DEBUG):
         assert (
@@ -338,13 +338,13 @@ def test_wait_for_session_running(requests_mock: Mocker) -> None:
         },
     )
 
-    api = AuraApi.create("", "", tenant_id="some-tenant")
+    api = AuraApi("", "", tenant_id="some-tenant")
 
     assert api.wait_for_session_running("id0") == WaitResult.from_connection_url("neo4j+s://foo.bar")
 
 
 def test_delete_instance(requests_mock: Mocker) -> None:
-    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
 
     mock_auth_token(requests_mock)
 
@@ -382,7 +382,7 @@ def test_delete_instance(requests_mock: Mocker) -> None:
 
 
 def test_delete_already_deleting_instance(requests_mock: Mocker) -> None:
-    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
 
     mock_auth_token(requests_mock)
     requests_mock.delete(
@@ -397,7 +397,7 @@ def test_delete_already_deleting_instance(requests_mock: Mocker) -> None:
 
 
 def test_delete_that_fails(requests_mock: Mocker) -> None:
-    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
 
     mock_auth_token(requests_mock)
     requests_mock.delete(
@@ -412,7 +412,7 @@ def test_delete_that_fails(requests_mock: Mocker) -> None:
 
 
 def test_create_instance(requests_mock: Mocker) -> None:
-    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
 
     mock_auth_token(requests_mock)
 
@@ -452,7 +452,7 @@ def test_create_instance(requests_mock: Mocker) -> None:
 
 
 def test_warn_about_expirying_endpoint(requests_mock: Mocker) -> None:
-    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
 
     mock_auth_token(requests_mock)
     requests_mock.delete(
@@ -466,7 +466,7 @@ def test_warn_about_expirying_endpoint(requests_mock: Mocker) -> None:
 
 
 def test_auth_token(requests_mock: Mocker) -> None:
-    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
 
     requests_mock.post(
         "https://api.neo4j.io/oauth/token",
@@ -484,7 +484,7 @@ def test_auth_token(requests_mock: Mocker) -> None:
 
 
 def test_auth_token_reused(requests_mock: Mocker) -> None:
-    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
 
     requests_mock.post(
         "https://api.neo4j.io/oauth/token",
@@ -503,7 +503,7 @@ def test_auth_token_reused(requests_mock: Mocker) -> None:
 
 
 def test_auth_token_use_short_token(requests_mock: Mocker) -> None:
-    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
 
     requests_mock.post(
         "https://api.neo4j.io/oauth/token",
@@ -522,7 +522,7 @@ def test_derive_tenant(requests_mock: Mocker) -> None:
         json={"data": [{"id": "6981ace7-efe8-4f5c-b7c5-267b5162ce91", "name": "Production"}]},
     )
 
-    AuraApi.create(client_id="", client_secret="")
+    AuraApi(client_id="", client_secret="")
 
 
 def test_raise_on_missing_tenant(requests_mock: Mocker) -> None:
@@ -540,11 +540,11 @@ def test_raise_on_missing_tenant(requests_mock: Mocker) -> None:
     )
 
     with pytest.raises(RuntimeError, match="This account has access to multiple tenants"):
-        AuraApi.create(client_id="", client_secret="")
+        AuraApi(client_id="", client_secret="")
 
 
 def test_list_instance(requests_mock: Mocker) -> None:
-    api = AuraApi.create(client_id="", client_secret="", tenant_id="YOUR_TENANT_ID")
+    api = AuraApi(client_id="", client_secret="", tenant_id="YOUR_TENANT_ID")
 
     mock_auth_token(requests_mock)
     requests_mock.get(
@@ -573,7 +573,7 @@ def test_list_instance(requests_mock: Mocker) -> None:
 
 
 def test_list_instance_missing_memory_field(requests_mock: Mocker) -> None:
-    api = AuraApi.create(client_id="", client_secret="", tenant_id="some-tenant")
+    api = AuraApi(client_id="", client_secret="", tenant_id="some-tenant")
 
     mock_auth_token(requests_mock)
     requests_mock.get(
@@ -600,7 +600,7 @@ def test_list_instance_missing_memory_field(requests_mock: Mocker) -> None:
 
 
 def test_list_missing_instance(requests_mock: Mocker) -> None:
-    api = AuraApi.create("", "", tenant_id="some-tenant")
+    api = AuraApi("", "", tenant_id="some-tenant")
 
     mock_auth_token(requests_mock)
 
@@ -633,7 +633,7 @@ def test_dont_wait_forever(requests_mock: Mocker, caplog: LogCaptureFixture) -> 
         },
     )
 
-    api = AuraApi.create("", "", tenant_id="some-tenant")
+    api = AuraApi("", "", tenant_id="some-tenant")
 
     with caplog.at_level(logging.DEBUG):
         assert (
@@ -663,7 +663,7 @@ def test_wait_for_instance_running(requests_mock: Mocker) -> None:
         },
     )
 
-    api = AuraApi.create("", "", tenant_id="some-tenant")
+    api = AuraApi("", "", tenant_id="some-tenant")
 
     assert api.wait_for_instance_running("id0") == WaitResult.from_connection_url("foo.bar")
 
@@ -703,7 +703,7 @@ def test_wait_for_instance_deleting(requests_mock: Mocker) -> None:
         },
     )
 
-    api = AuraApi.create("", "", tenant_id="some-tenant")
+    api = AuraApi("", "", tenant_id="some-tenant")
 
     assert api.wait_for_instance_running("id0") == WaitResult.from_error("Instance is being deleted")
     assert api.wait_for_instance_running("id1") == WaitResult.from_error("Instance is being deleted")
@@ -716,7 +716,7 @@ def test_estimate_size(requests_mock: Mocker) -> None:
         json={"data": {"did_exceed_maximum": True, "min_required_memory": "307GB", "recommended_size": "96GB"}},
     )
 
-    api = AuraApi.create("", "", tenant_id="some-tenant")
+    api = AuraApi("", "", tenant_id="some-tenant")
     assert api.estimate_size(100, 10, [AlgorithmCategory.NODE_EMBEDDING]) == EstimationDetails("307GB", "96GB", True)
 
 

--- a/graphdatascience/tests/unit/test_aurads_sessions.py
+++ b/graphdatascience/tests/unit/test_aurads_sessions.py
@@ -28,7 +28,7 @@ class FakeAuraApi(AuraApi):
         status_after_creating: str = "running",
         size_estimation: Optional[EstimationDetails] = None,
     ) -> None:
-        super().__init__("", "", "tenant_id")
+        super().__init__("aura.api", "client_id", "client_secret", "tenant_id")
         if existing_instances is None:
             existing_instances = []
         self._instances = {details.id: details for details in existing_instances}

--- a/graphdatascience/tests/unit/test_aurads_sessions.py
+++ b/graphdatascience/tests/unit/test_aurads_sessions.py
@@ -28,7 +28,7 @@ class FakeAuraApi(AuraApi):
         status_after_creating: str = "running",
         size_estimation: Optional[EstimationDetails] = None,
     ) -> None:
-        super().__init__("aura.api", "client_id", "client_secret", "tenant_id")
+        super().__init__("client_id", "client_secret", "tenant_id")
         if existing_instances is None:
             existing_instances = []
         self._instances = {details.id: details for details in existing_instances}

--- a/graphdatascience/tests/unit/test_dedicated_sessions.py
+++ b/graphdatascience/tests/unit/test_dedicated_sessions.py
@@ -31,7 +31,7 @@ class FakeAuraApi(AuraApi):
         status_after_creating: str = "Ready",
         size_estimation: Optional[EstimationDetails] = None,
     ) -> None:
-        super().__init__("", "", "tenant_id")
+        super().__init__("https://aura.api", "client_id", "client_secret", "tenant_id")
         if existing_instances is None:
             existing_instances = []
         if existing_sessions is None:


### PR DESCRIPTION
makes it harder to reuse.
Also simplifies the constructor
