### PR TITLE
Session - get_or_create: Reuse db driver

### DIFF
--- a/doc/modules/ROOT/pages/tutorials/gds-sessions-self-managed.adoc
+++ b/doc/modules/ROOT/pages/tutorials/gds-sessions-self-managed.adoc
@@ -35,7 +35,7 @@ version `+1.12a1+` or later.
 ----
 from datetime import timedelta
 
-%pip install "graphdatascience>=1.12a1"
+%pip install "graphdatascience>=1.12"
 ----
 
 == Aura API credentials
@@ -84,9 +84,21 @@ delete the session ourselves.
 
 [source, python, role=no-test]
 ----
+from graphdatascience.session import AlgorithmCategory
+
+# Estimate the memory needed for the GDS session
+memory = sessions.estimate(
+    node_count=20,
+    relationship_count=50,
+    algorithm_categories=[AlgorithmCategory.CENTRALITY, AlgorithmCategory.NODE_EMBEDDING],
+)
+----
+
+[source, python, role=no-test]
+----
 import os
 
-from graphdatascience.session import AlgorithmCategory, CloudLocation, DbmsConnectionInfo
+from graphdatascience.session import CloudLocation, DbmsConnectionInfo
 
 # Identify the Neo4j DBMS
 db_connection = DbmsConnectionInfo(
@@ -96,11 +108,6 @@ db_connection = DbmsConnectionInfo(
 cloud_location = CloudLocation(provider="gcp", region="europe-west1")
 
 # Create a GDS session!
-memory = sessions.estimate(
-    node_count=20,
-    relationship_count=50,
-    algorithm_categories=[AlgorithmCategory.CENTRALITY, AlgorithmCategory.NODE_EMBEDDING],
-)
 gds = sessions.get_or_create(
     # we give it a representative name
     session_name="people-and-fruits-sm",

--- a/doc/modules/ROOT/pages/tutorials/gds-sessions.adoc
+++ b/doc/modules/ROOT/pages/tutorials/gds-sessions.adoc
@@ -34,7 +34,7 @@ version `+1.12a1+` or later.
 
 [source, python, role=no-test]
 ----
-%pip install "graphdatascience>=1.12a1"
+%pip install "graphdatascience>=1.12"
 ----
 
 == Aura API credentials
@@ -83,21 +83,26 @@ delete the session ourselves.
 
 [source, python, role=no-test]
 ----
-import os
-from datetime import timedelta
-
 from graphdatascience.session import AlgorithmCategory, DbmsConnectionInfo
 
-# Identify the AuraDB instance
-db_connection = DbmsConnectionInfo(
-    uri=os.environ["AURA_DB_ADDRESS"], username=os.environ["AURA_DB_USER"], password=os.environ["AURA_DB_PW"]
-)
-# Create a GDS session!
+# Estimate the memory needed for the GDS session
 memory = sessions.estimate(
     node_count=20,
     relationship_count=50,
     algorithm_categories=[AlgorithmCategory.CENTRALITY, AlgorithmCategory.NODE_EMBEDDING],
 )
+----
+
+[source, python, role=no-test]
+----
+from datetime import timedelta
+
+# Identify the AuraDB instance
+db_connection = DbmsConnectionInfo(
+    uri=os.environ["AURA_DB_ADDRESS"], username=os.environ["AURA_DB_USER"], password=os.environ["AURA_DB_PW"]
+)
+
+# Create a GDS session!
 gds = sessions.get_or_create(
     # we give it a representative name
     session_name="people-and-fruits",
@@ -186,7 +191,7 @@ algorithms, although we do not do that in this notebook.
 [source, python, role=no-test]
 ----
 G, result = gds.graph.project(
-    "people-and-fruits",
+    "people-and-fruits-2",
     """
     CALL {
         MATCH (p1:Person)

--- a/doc/modules/ROOT/pages/tutorials/gds-sessions.adoc
+++ b/doc/modules/ROOT/pages/tutorials/gds-sessions.adoc
@@ -191,7 +191,7 @@ algorithms, although we do not do that in this notebook.
 [source, python, role=no-test]
 ----
 G, result = gds.graph.project(
-    "people-and-fruits-2",
+    "people-and-fruits",
     """
     CALL {
         MATCH (p1:Person)

--- a/examples/gds-sessions-self-managed.ipynb
+++ b/examples/gds-sessions-self-managed.ipynb
@@ -60,7 +60,7 @@
    "source": [
     "from datetime import timedelta\n",
     "\n",
-    "%pip install \"graphdatascience>=1.12a1\""
+    "%pip install \"graphdatascience>=1.12\""
    ]
   },
   {
@@ -122,9 +122,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from graphdatascience.session import AlgorithmCategory\n",
+    "\n",
+    "# Estimate the memory needed for the GDS session\n",
+    "memory = sessions.estimate(\n",
+    "    node_count=20,\n",
+    "    relationship_count=50,\n",
+    "    algorithm_categories=[AlgorithmCategory.CENTRALITY, AlgorithmCategory.NODE_EMBEDDING],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import os\n",
     "\n",
-    "from graphdatascience.session import AlgorithmCategory, CloudLocation, DbmsConnectionInfo\n",
+    "from graphdatascience.session import CloudLocation, DbmsConnectionInfo\n",
     "\n",
     "# Identify the Neo4j DBMS\n",
     "db_connection = DbmsConnectionInfo(\n",
@@ -134,11 +150,6 @@
     "cloud_location = CloudLocation(provider=\"gcp\", region=\"europe-west1\")\n",
     "\n",
     "# Create a GDS session!\n",
-    "memory = sessions.estimate(\n",
-    "    node_count=20,\n",
-    "    relationship_count=50,\n",
-    "    algorithm_categories=[AlgorithmCategory.CENTRALITY, AlgorithmCategory.NODE_EMBEDDING],\n",
-    ")\n",
     "gds = sessions.get_or_create(\n",
     "    # we give it a representative name\n",
     "    session_name=\"people-and-fruits-sm\",\n",

--- a/examples/gds-sessions.ipynb
+++ b/examples/gds-sessions.ipynb
@@ -58,7 +58,7 @@
    },
    "outputs": [],
    "source": [
-    "%pip install \"graphdatascience>=1.12a1\""
+    "%pip install \"graphdatascience>=1.12\""
    ]
   },
   {
@@ -120,21 +120,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "from datetime import timedelta\n",
-    "\n",
     "from graphdatascience.session import AlgorithmCategory, DbmsConnectionInfo\n",
+    "\n",
+    "# Estimate the memory needed for the GDS session\n",
+    "memory = sessions.estimate(\n",
+    "    node_count=20,\n",
+    "    relationship_count=50,\n",
+    "    algorithm_categories=[AlgorithmCategory.CENTRALITY, AlgorithmCategory.NODE_EMBEDDING],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import timedelta\n",
     "\n",
     "# Identify the AuraDB instance\n",
     "db_connection = DbmsConnectionInfo(\n",
     "    uri=os.environ[\"AURA_DB_ADDRESS\"], username=os.environ[\"AURA_DB_USER\"], password=os.environ[\"AURA_DB_PW\"]\n",
     ")\n",
+    "\n",
     "# Create a GDS session!\n",
-    "memory = sessions.estimate(\n",
-    "    node_count=20,\n",
-    "    relationship_count=50,\n",
-    "    algorithm_categories=[AlgorithmCategory.CENTRALITY, AlgorithmCategory.NODE_EMBEDDING],\n",
-    ")\n",
     "gds = sessions.get_or_create(\n",
     "    # we give it a representative name\n",
     "    session_name=\"people-and-fruits\",\n",

--- a/graphdatascience/query_runner/neo4j_query_runner.py
+++ b/graphdatascience/query_runner/neo4j_query_runner.py
@@ -283,6 +283,12 @@ class Neo4jQueryRunner(QueryRunner):
 
         raise SyntaxError(generate_suggestive_error_message(requested_endpoint, all_endpoints)) from e
 
+    def verify_connectivity(self) -> None:
+        self._driver.verify_connectivity()
+
+    def verify_authentication(self) -> None:
+        self._driver.verify_authentication()
+
     def _verify_connectivity(self, database: Optional[str] = None) -> None:
         WAIT_TIME = 1
         MAX_RETRYS = 10 * 60

--- a/graphdatascience/session/aura_graph_data_science.py
+++ b/graphdatascience/session/aura_graph_data_science.py
@@ -30,7 +30,7 @@ class AuraGraphDataScience(DirectEndpoints, UncallableNamespace):
     def create(
         cls,
         gds_session_connection_info: DbmsConnectionInfo,
-        db_connection_info: DbmsConnectionInfo,
+        db_endpoint: Neo4jQueryRunner | DbmsConnectionInfo,
         delete_fn: Callable[[], bool],
         arrow_disable_server_verification: bool = False,
         arrow_tls_root_certs: Optional[bytes] = None,
@@ -67,13 +67,16 @@ class AuraGraphDataScience(DirectEndpoints, UncallableNamespace):
             arrow_tls_root_certs,
         )
 
-        db_bolt_query_runner = Neo4jQueryRunner.create(
-            db_connection_info.uri,
-            db_connection_info.auth(),
-            aura_ds=True,
-            show_progress=False,
-            database=db_connection_info.database,
-        )
+        if isinstance(db_endpoint, Neo4jQueryRunner):
+            db_bolt_query_runner = db_endpoint
+        else:
+            db_bolt_query_runner = Neo4jQueryRunner.create(
+                db_endpoint.uri,
+                db_endpoint.auth(),
+                aura_ds=True,
+                show_progress=False,
+                database=db_endpoint.database,
+            )
         db_bolt_query_runner.set_bookmarks(bookmarks)
 
         session_query_runner = SessionQueryRunner.create(

--- a/graphdatascience/session/aura_graph_data_science.py
+++ b/graphdatascience/session/aura_graph_data_science.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, Union
 
 from pandas import DataFrame
 
@@ -30,7 +30,7 @@ class AuraGraphDataScience(DirectEndpoints, UncallableNamespace):
     def create(
         cls,
         gds_session_connection_info: DbmsConnectionInfo,
-        db_endpoint: Neo4jQueryRunner | DbmsConnectionInfo,
+        db_endpoint: Union[Neo4jQueryRunner, DbmsConnectionInfo],
         delete_fn: Callable[[], bool],
         arrow_disable_server_verification: bool = False,
         arrow_tls_root_certs: Optional[bytes] = None,

--- a/graphdatascience/session/dedicated_sessions.py
+++ b/graphdatascience/session/dedicated_sessions.py
@@ -48,8 +48,8 @@ class DedicatedSessions:
         cloud_location: Optional[CloudLocation] = None,
     ) -> AuraGraphDataScience:
         db_runner = Neo4jQueryRunner.create(
-            db_connection.uri,
-            db_connection.auth(),
+            endpoint=db_connection.uri,
+            auth=db_connection.auth(),
             aura_ds=True,
             show_progress=False,
             database=db_connection.database,

--- a/graphdatascience/tests/integration/conftest.py
+++ b/graphdatascience/tests/integration/conftest.py
@@ -93,7 +93,7 @@ def gds_without_arrow() -> Generator[GraphDataScience, None, None]:
 def gds_with_cloud_setup(request: pytest.FixtureRequest) -> Generator[AuraGraphDataScience, None, None]:
     _gds = AuraGraphDataScience.create(
         gds_session_connection_info=DbmsConnectionInfo(URI, AUTH[0], AUTH[1]),
-        db_connection_info=DbmsConnectionInfo(AURA_DB_URI, AURA_DB_AUTH[0], AURA_DB_AUTH[1]),
+        db_endpoint=DbmsConnectionInfo(AURA_DB_URI, AURA_DB_AUTH[0], AURA_DB_AUTH[1]),
         delete_fn=lambda: True,
     )
     _gds.set_database(DB)

--- a/graphdatascience/tests/unit/conftest.py
+++ b/graphdatascience/tests/unit/conftest.py
@@ -177,7 +177,7 @@ def aura_gds(runner: CollectingQueryRunner, mocker: MockerFixture) -> Generator[
 
     aura_gds = AuraGraphDataScience.create(
         gds_session_connection_info=DbmsConnectionInfo("address", "some", "auth"),
-        db_connection_info=DbmsConnectionInfo("address", "some", "auth"),
+        db_endpoint=DbmsConnectionInfo("address", "some", "auth"),
         delete_fn=lambda: True,
     )
     yield aura_gds


### PR DESCRIPTION
We can save a bit of time by reusing the driver we create to test the db credentials.

Also realized, that the sessions.estimate call was taking up to 5s.
By moving it into its own cell its better to see how fast get_or_create can get.