### PR TITLE
fix: remove flight client from serialization

### DIFF
--- a/graphdatascience/query_runner/gds_arrow_client.py
+++ b/graphdatascience/query_runner/gds_arrow_client.py
@@ -96,8 +96,6 @@ class GdsArrowClient:
 
         if auth:
             self._auth_middleware = AuthMiddleware(auth)
-            if not self._user_agent:
-                self._user_agent = f"neo4j-graphdatascience-v{__version__} pyarrow-v{arrow_version}"
 
         self._flight_client = self._instantiate_flight_client()
 
@@ -109,9 +107,13 @@ class GdsArrowClient:
         )
         client_options: dict[str, Any] = {"disable_server_verification": self._disable_server_verification}
         if self._auth:
+            user_agent = f"neo4j-graphdatascience-v{__version__} pyarrow-v{arrow_version}"
+            if self._user_agent:
+                user_agent = self._user_agent
+
             client_options["middleware"] = [
                 AuthFactory(self._auth_middleware),
-                UserAgentFactory(useragent=self._user_agent),
+                UserAgentFactory(useragent=user_agent),
             ]
         if self._tls_root_certs:
             client_options["tls_root_certs"] = self._tls_root_certs

--- a/graphdatascience/query_runner/gds_arrow_client.py
+++ b/graphdatascience/query_runner/gds_arrow_client.py
@@ -7,7 +7,7 @@ import time
 import warnings
 from dataclasses import dataclass
 from types import TracebackType
-from typing import Any, Callable, Iterable, Optional, Type, Union, Dict
+from typing import Any, Callable, Dict, Iterable, Optional, Type, Union
 
 import pyarrow
 from neo4j.exceptions import ClientError

--- a/graphdatascience/query_runner/gds_arrow_client.py
+++ b/graphdatascience/query_runner/gds_arrow_client.py
@@ -102,10 +102,17 @@ class GdsArrowClient:
         self._flight_client = self._instantiate_flight_client()
 
     def _instantiate_flight_client(self) -> flight.FlightClient:
-        location = flight.Location.for_grpc_tls(self._host, self._port) if self._encrypted else flight.Location.for_grpc_tcp(self._host, self._port)
+        location = (
+            flight.Location.for_grpc_tls(self._host, self._port)
+            if self._encrypted
+            else flight.Location.for_grpc_tcp(self._host, self._port)
+        )
         client_options: dict[str, Any] = {"disable_server_verification": self._disable_server_verification}
         if self._auth:
-            client_options["middleware"] = [AuthFactory(self._auth_middleware), UserAgentFactory(useragent=self._user_agent)]
+            client_options["middleware"] = [
+                AuthFactory(self._auth_middleware),
+                UserAgentFactory(useragent=self._user_agent),
+            ]
         if self._tls_root_certs:
             client_options["tls_root_certs"] = self._tls_root_certs
         return flight.FlightClient(location, **client_options)
@@ -543,7 +550,7 @@ class GdsArrowClient:
             A callback function that is called with the number of rows uploaded after each batch
         """
         self._upload_data(graph_name, "triplet", triplet_data, batch_size, progress_callback)
-        
+
     def __getstate__(self) -> Dict[str, Any]:
         state = self.__dict__.copy()
         # Remove the FlightClient as it isn't serializable


### PR DESCRIPTION

This PR fixes serialization issues with the FlightClient in the GDSArrowClient class. Due to its non-serializability.

- Added a `_instantiate_flight_client()` method to create the `FlightClient` with proper configuration.
- Implemented a `_client()` method for lazy construction of the `FlightClient`, ensuring it’s only instantiated when needed.
- Modified the `__getstate__()` method to exclude the `FlightClient` from the serialized state.
