### PR TITLE
fix: use serialisation helper function

### DIFF
--- a/graphdatascience/query_runner/gds_arrow_client.py
+++ b/graphdatascience/query_runner/gds_arrow_client.py
@@ -654,8 +654,9 @@ class GdsArrowClient:
 
         ticket = flight.Ticket(json.dumps(payload).encode("utf-8"))
 
+        client = self._client()
         try:
-            get = self._flight_client.do_get(ticket)
+            get = client.do_get(ticket)
             arrow_table = get.read_all()
         except Exception as e:
             self.handle_flight_error(e)

--- a/graphdatascience/query_runner/gds_arrow_client.py
+++ b/graphdatascience/query_runner/gds_arrow_client.py
@@ -140,7 +140,8 @@ class GdsArrowClient:
             a token from the server and returns it.
         """
         if self._auth:
-            self._flight_client.authenticate_basic_token(self._auth[0], self._auth[1])
+            client = self._client()
+            client.authenticate_basic_token(self._auth[0], self._auth[1])
             return self._auth_middleware.token()
         else:
             return "IGNORED"
@@ -684,10 +685,11 @@ class GdsArrowClient:
         exception_value: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> None:
-        self._flight_client.close()
+        self.close()
 
     def close(self) -> None:
-        self._flight_client.close()
+        if self._flight_client:
+            self._flight_client.close()
 
     def _versioned_action_type(self, action_type: str) -> str:
         return self._arrow_endpoint_version.prefix() + action_type


### PR DESCRIPTION
## [Issue](https://trello.com/c/cUx7Uz5L/805-move-to-gds-client-library-instead-of-neo4jarrow#)
When calling the GDS read functions we are not using the lazy serialisation client. 
This is required for the BigQueryConnector which uses this library instead of neo4j-arrow.
Follow-up from: #804 

## Fix
Use `self._client()` instead of the `_flight_client` directly so that it can be lazy initialised if needed.

