### PR TITLE
remove sitemap extension

### DIFF
--- a/doc/preview.yml
+++ b/doc/preview.yml
@@ -26,13 +26,6 @@ runtime:
 urls:
   html_extension_style: indexify
 
-antora:
-  extensions:
-  - require: "@neo4j-antora/antora-modify-sitemaps"
-    sitemap_version: '1.15-preview'
-    sitemap_loc_version: 'current'
-    move_sitemaps_to_components: true
-
 asciidoc:
   extensions:
   - "@neo4j-documentation/remote-include"

--- a/doc/publish.yml
+++ b/doc/publish.yml
@@ -23,14 +23,6 @@ ui:
 urls:
   html_extension_style: indexify
 
-antora:
-  extensions:
-  - require: "@neo4j-antora/antora-modify-sitemaps"
-    # the current stable version
-    sitemap_version: '1.12'
-    sitemap_loc_version: current
-    move_sitemaps_to_components: 'true'
-
 asciidoc:
   extensions:
   - "@neo4j-documentation/remote-include"


### PR DESCRIPTION
This PR removes the `antora-modify-sitemaps` extension from the docs playbooks. We no longer need to include this in the playbook because it is automatically applied with the correct configuration in publishing builds.