### PR TITLE
Mark release as prerelease in antora.yml

### DIFF
--- a/doc/antora.yml
+++ b/doc/antora.yml
@@ -1,6 +1,7 @@
 name: graph-data-science-client
 title: Neo4j Graph Data Science Client
 version: '1.15-preview'
+prerelease: true
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc


### PR DESCRIPTION
In order to produce accurate canonical URLs in docs output we need to mark the preview release with `prerelease: true` in _antora.yml_.

An update to the docs ui-bundle will allow the prerelease to be available from the version selector along with released versions.

When the branch for this release is created, and _antora.yml_ is updated by changing the version from `1.15-preview` to `1.15` the prerelease attribute should be removed at the same time.