### PR TITLE
Polish sessions docs (1.15)

### DIFF
--- a/doc/modules/ROOT/content-nav.adoc
+++ b/doc/modules/ROOT/content-nav.adoc
@@ -1,6 +1,7 @@
 * xref:index.adoc[Introduction]
 * xref:installation.adoc[]
 * xref:getting-started.adoc[]
+* xref:graph-analytics-serverless.adoc[]
 * xref:graph-object.adoc[]
 * xref:algorithms.adoc[]
 * xref:pipelines.adoc[]
@@ -8,7 +9,6 @@
 * xref:common-datasets.adoc[]
 * xref:rel-embedding-models.adoc[]
 * xref:bookmarks.adoc[]
-* xref:graph-analytics-serverless.adoc[]
 * xref:visualization.adoc[]
 * xref:tutorials/tutorials.adoc[]
 // https://docs.antora.org/antora/latest/navigation/include-lists/

--- a/doc/modules/ROOT/pages/getting-started.adoc
+++ b/doc/modules/ROOT/pages/getting-started.adoc
@@ -42,6 +42,26 @@ Please note that the `GraphDataScience` object needs to communicate with a Neo4j
 If there is no such database, you will need to <<specifying-targeted-database, provide a valid database using the `database` keyword parameter>>.
 
 
+=== Aura Graph Analytics Serverless
+
+The GDS Python Client has dedicated support for the Aura Graph Analytics Serverless offering.
+Below we illustrate how to instantiate the `GraphDataScience` object using an Aura API key pair and AuraDB connection information.
+
+[source,python,role=no-test]
+----
+from graphdatascience.session import DbmsConnectionInfo, GdsSessions, AuraAPICredentials, SessionMemory
+
+sessions = GdsSessions(api_credentials=AuraAPICredentials("<clientId>", "<clientSecret>"))
+gds = sessions.get_or_create(
+    session_name="my-session",
+    memory=SessionMemory.m_4GB,
+    db_connection=DbmsConnectionInfo("neo4j+s://mydbid.databases.neo4j.io", "neo4j", "<password>"),
+)
+----
+
+Full details covering all that you can do with this service is found on xref:graph-analytics-serverless.adoc[the dedicated page].
+
+
 === AuraDS
 
 If you are connecting the client to an https://neo4j.com/cloud/graph-data-science/[AuraDS instance], you can get recommended non-default configuration settings of the Python Driver applied automatically.

--- a/doc/modules/ROOT/pages/getting-started.adoc
+++ b/doc/modules/ROOT/pages/getting-started.adoc
@@ -44,8 +44,9 @@ If there is no such database, you will need to <<specifying-targeted-database, p
 
 === Aura Graph Analytics Serverless
 
-The GDS Python Client has dedicated support for the Aura Graph Analytics Serverless offering.
-Below we illustrate how to instantiate the `GraphDataScience` object using an Aura API key pair and AuraDB connection information.
+The GDS Python Client has dedicated support for the xref:graph-analytics-serverless.adoc[Aura Graph Analytics Serverless] offering.
+
+This example shows how to instantiate the `GraphDataScience` object using an Aura API key pair and AuraDB connection information.
 
 [source,python,role=no-test]
 ----
@@ -58,8 +59,6 @@ gds = sessions.get_or_create(
     db_connection=DbmsConnectionInfo("neo4j+s://mydbid.databases.neo4j.io", "neo4j", "<password>"),
 )
 ----
-
-Full details covering all that you can do with this service is found on xref:graph-analytics-serverless.adoc[the dedicated page].
 
 
 === AuraDS

--- a/doc/modules/ROOT/pages/graph-analytics-serverless.adoc
+++ b/doc/modules/ROOT/pages/graph-analytics-serverless.adoc
@@ -3,12 +3,22 @@
 :page-aliases: gds-session
 
 Aura Graph Analytics Serverless is an on-demand ephemeral compute environment for running GDS workloads.
-Each compute unit is called a GDS Session.
-It is offered as part of Neo4j Aura, a fast, scalable, always-on, fully automated cloud graph platform.
+Each compute unit is called a _GDS Session_.
+It is offered as part of link:https://neo4j.com/docs/aura/graph-analytics/[Neo4j Aura], a fast, scalable, always-on, fully automated cloud graph platform.
 
-A GDS Session reads data from a Neo4j DBMS through a _remote projection_, runs computations on the projected graph, and optionally writes the results back to the DBMS using _remote write-back_.
+NOTE: Aura Graph Analytics Serverless is not available by default.
+See the Aura https://neo4j.com/docs/aura/graph-analytics/#aura-gds-serverless[docs] for details on how to enable it.
 
-NOTE: Graph Analytics Serverless is not available by default. See the Aura https://neo4j.com/docs/aura/graph-analytics/#aura-gds-serverless[docs] for details on how to enable it.
+A GDS Session is in one of three flavours, determined by its data source:
+
+* *Attached*, sourced from a Neo4j AuraDB instance.
+* *Self-managed*, sourced from a self-managed Neo4j DBMS.
+* *Standalone*, sourced from a non-Neo4j data source.
+
+
+We call the process of populating the session with data a _remote projection_.
+Once populated, a GDS Session can run GDS workloads, such as algorithms and machine learning models.
+Results from these computations can be written back to the original source, using _remote write-back_ in the Attached and Self-managed flavours.
 
 TIP: For ready-to-run notebooks, see our tutorials on GDS Sessions for xref:tutorials/graph-analytics-serverless.adoc[AuraDB] and xref:tutorials/graph-analytics-serverless-self-managed[self-managed databases].
 

--- a/doc/modules/ROOT/pages/graph-analytics-serverless.adoc
+++ b/doc/modules/ROOT/pages/graph-analytics-serverless.adoc
@@ -198,6 +198,24 @@ sessions.delete(session_name="my-new-session")
 ----
 
 
+=== Estimating session memory
+
+In order to help determine a good session size for a given workload, there is the `estimate()` function.
+By providing expected node and relationship counts as well as algorithm categories that should be used, it will return an estimated size of the session.
+
+.Estimating the size of a GDS Session via the GdsSessions object:
+[source, python, role=no-test]
+----
+from graphdatascience.session import AlgorithmCategory
+
+memory = sessions.estimate(
+    node_count=20,
+    relationship_count=50,
+    algorithm_categories=[AlgorithmCategory.CENTRALITY, AlgorithmCategory.NODE_EMBEDDING],
+)
+----
+
+
 == Projecting graphs into a GDS Session
 
 Once you have a GDS Session, you can project a graph into it.

--- a/doc/modules/ROOT/pages/graph-analytics-serverless.adoc
+++ b/doc/modules/ROOT/pages/graph-analytics-serverless.adoc
@@ -65,31 +65,56 @@ As a convention, always use the variable name `gds` for the return value of `get
 
 ==== Syntax
 
-To create a GDS Session, you need to provide the following information:
+[source, role=no-test]
+----
+sessions.get_or_create(
+    session_name: str,
+    memory: SessionMemory,
+    db_connection: Optional[DbmsConnectionInfo] = None,
+    ttl: Optional[timedelta] = None,
+    cloud_location: Optional[CloudLocation] = None,
+    timeout: Optional[int] = None,
+): AuraGraphDataScience
+----
 
-- **Session name**.
-The name must be unique.
+.Parameters:
+[opts="header",cols="3m,1,1m,6", role="no-break"]
+|===
+| Name                               | Optional | Default | Description
+| session_name                       | no       | -       | Name of the session. Must be unique within the project.
+| memory                             | no       | -       | Amount of memory available to the session. https://neo4j.com/docs/graph-data-science-client/{docs-version}/api/sessions/session_memory[Supported values].
+| db_connection                      | yes      | None    | Bolt server URL, username, and password to a Neo4j DBMS. Required for the Attached and Self-managed flavours.
+| ttl                                | yes      | 1h      | Time-to-live for the session.
+| cloud_location                     | yes      | None    | Aura-supported cloud provider and region where the GDS Session will run. Required for the Self-managed and Standalone flavours.
+| timeout                            | yes      | None    | Seconds to wait for the session to enter Ready state. If the time is exceeded, an error will be returned.
+|===
 
-- **Session memory**.
-This configuration determines the amount of memory and CPU available to the session.
-It also determines the cost of running the session.
-Available configurations are listed in our API https://neo4j.com/docs/graph-data-science-client/{docs-version}/api/sessions/session_memory[reference].
-You can use the `sessions.estimate()` method to estimate the size required.
-Available algorithm categories are listed in our API https://neo4j.com/docs/graph-data-science-client/{docs-version}/api/sessions/algorithm_category[reference].
 
-- **DBMS connection**.
-This optional parameter is a `DbmsConnectionInfo` object that contains the URI of an Neo4j instance, a username, and a password. It is required if either a graph projection from a database or a write-back to a database is needed.
-If not specified, graphs can be xref:graph-object.adoc#construct[constructed via arrow].
-
-- **TTL**.
-This optional parameter specifies the time-to-live of the session.
-The session will be automatically deleted if the session was unused for the provided duration.
-Usage is defined as the computation of an algorithm or the projection of a graph.
-By default, the session will be deleted after 1 hour of inactivity.
-
-- **Cloud location**.
-This is a `CloudLocation` object that specifies the cloud provider and region where the GDS Session will run. Required if the DBMS connection is for a self-managed database.
-Use `sessions.available_cloud_locations()` to find out which locations are available.
+// To create a GDS Session, you need to provide the following information:
+//
+// - **Session name**.
+// The name must be unique.
+//
+// - **Session memory**.
+// This configuration determines the amount of memory and CPU available to the session.
+// It also determines the cost of running the session.
+// Available configurations are listed in our API https://neo4j.com/docs/graph-data-science-client/{docs-version}/api/sessions/session_memory[reference].
+// You can use the `sessions.estimate()` method to estimate the size required.
+// Available algorithm categories are listed in our API https://neo4j.com/docs/graph-data-science-client/{docs-version}/api/sessions/algorithm_category[reference].
+//
+// - **DBMS connection**.
+// This optional parameter is a `DbmsConnectionInfo` object that contains the URI of an Neo4j instance, a username, and a password. It is required if either a graph projection from a database or a write-back to a database is needed.
+// If not specified, graphs can be xref:graph-object.adoc#construct[constructed via arrow].
+//
+// - **TTL**.
+// This optional parameter specifies the time-to-live of the session.
+// The session will be automatically deleted if the session was unused for the provided duration.
+// Usage is defined as the computation of an algorithm or the projection of a graph.
+// By default, the session will be deleted after 1 hour of inactivity.
+//
+// - **Cloud location**.
+// This is a `CloudLocation` object that specifies the cloud provider and region where the GDS Session will run. Required if the DBMS connection is for a self-managed database.
+// Use `sessions.available_cloud_locations()` to find out which locations are available.
 
 
 ==== Examples

--- a/doc/modules/ROOT/pages/graph-analytics-serverless.adoc
+++ b/doc/modules/ROOT/pages/graph-analytics-serverless.adoc
@@ -32,9 +32,9 @@ The `GdsSessions` object is the API entry point to the following operations:
 - `delete`: Delete a GDS Session.
 
 
-
 You need Neo4j Aura API credentials (`CLIENT_ID` and `CLIENT_SECRET`) to create a `GdsSessions` object.
 See the link:{neo4j-docs-base-uri}/aura/platform/api/authentication/#_creating_credentials[Aura documentation] for instructions on how to create API credentials from your Neo4j Aura account.
+If your Aura user is part of multiple projects, the desired project ID must also be provided.
 
 .Creating a GdsSessions object:
 [source, python, role=no-test]
@@ -43,14 +43,14 @@ from graphdatascience.session import GdsSessions, AuraAPICredentials
 
 CLIENT_ID = "my-aura-api-client-id"
 CLIENT_SECRET = "my-aura-api-client-secret"
-# Needs to be specified if your Aura account has multiple projects
 PROJECT_ID = None
 
 # Create a new GdsSessions object
 sessions = GdsSessions(api_credentials=AuraAPICredentials(CLIENT_ID, CLIENT_SECRET, PROJECT_ID))
 ----
 
-All available methods and parameters are listed in our API https://neo4j.com/docs/graph-data-science-client/{docs-version}/api/sessions/session_memory[reference].
+All available methods and parameters are listed in our API https://neo4j.com/docs/graph-data-science-client/{docs-version}/api/sessions/gds_sessions/[reference].
+
 
 === Creating a GDS Session
 

--- a/doc/modules/ROOT/pages/graph-analytics-serverless.adoc
+++ b/doc/modules/ROOT/pages/graph-analytics-serverless.adoc
@@ -107,53 +107,40 @@ sessions.get_or_create(
 
 ==== Examples
 
-.Creating GDS Sessions
 [.tabbed-example, caption = ]
 =====
 
 [.include-with-attached]
 =======
 
-.Creating a GDS Session for an AuraDB instance:
+.Creating a GDS Session attached to an AuraDB instance:
 [source,python,role=no-test]
 ----
-from datetime import timedelta
-from graphdatascience.session import DbmsConnectionInfo, AlgorithmCategory
-
-memory = sessions.estimate(
-    node_count=20,
-    relationship_count=50,
-    algorithm_categories=[AlgorithmCategory.CENTRALITY, AlgorithmCategory.NODE_EMBEDDING],
-)
+from graphdatascience.session import DbmsConnectionInfo, SessionMemory
 
 gds = sessions.get_or_create(
-    session_name="my-new-session",
-    memory=memory,
-    db_connection=DbmsConnectionInfo("neo4j+s://mydbid.databases.neo4j.io", "my-user", "my-password"),
-    ttl=timedelta(hours=5),
+    session_name="my-attached-session",
+    memory=SessionMemory.m_4GB,
+    db_connection=DbmsConnectionInfo(
+        "neo4j+s://mydbid.databases.neo4j.io",
+        "my-user",
+        "my-password"
+    ),
 )
 ----
 =======
 
-[.include-with-self-Manged]
+[.include-with-self-managed]
 =======
-.Creating a GDS Session for a self-managed Neo4j database:
+.Creating a GDS Session for a self-managed Neo4j DBMS:
 [source,python,role=no-test]
 ----
-from datetime import timedelta
-from graphdatascience.session import DbmsConnectionInfo, AlgorithmCategory, CloudLocation
-
-memory = sessions.estimate(
-    node_count=20,
-    relationship_count=50,
-    algorithm_categories=[AlgorithmCategory.CENTRALITY, AlgorithmCategory.NODE_EMBEDDING],
-)
+from graphdatascience.session import DbmsConnectionInfo, CloudLocation, SessionMemory
 
 gds = sessions.get_or_create(
-    session_name="my-new-session-sm",
-    memory=memory,
+    session_name="my-self-managed-session",
+    memory=SessionMemory.m_4GB,
     db_connection=DbmsConnectionInfo("neo4j://localhost", "my-user", "my-password"),
-    ttl=timedelta(hours=2),
     cloud_location=CloudLocation(provider="gcp", region="europe-west1"),
 )
 ----
@@ -164,19 +151,11 @@ gds = sessions.get_or_create(
 .Creating a GDS Session without any Neo4j database:
 [source,python,role=no-test]
 ----
-from datetime import timedelta
-from graphdatascience.session import AlgorithmCategory, CloudLocation
-
-memory = sessions.estimate(
-    node_count=20,
-    relationship_count=50,
-    algorithm_categories=[AlgorithmCategory.CENTRALITY, AlgorithmCategory.NODE_EMBEDDING],
-)
+from graphdatascience.session import CloudLocation, SessionMemory
 
 gds = sessions.get_or_create(
-    session_name="my-new-session-sm",
-    memory=memory,
-    ttl=timedelta(hours=2),
+    session_name="my-standalone-session",
+    memory=SessionMemory.m_4GB,
     cloud_location=CloudLocation(provider="gcp", region="europe-west1"),
 )
 ----

--- a/doc/modules/ROOT/pages/graph-analytics-serverless.adoc
+++ b/doc/modules/ROOT/pages/graph-analytics-serverless.adoc
@@ -9,14 +9,14 @@ It is offered as part of link:https://neo4j.com/docs/aura/graph-analytics/[Neo4j
 NOTE: Aura Graph Analytics Serverless is not available by default.
 See the Aura https://neo4j.com/docs/aura/graph-analytics/#aura-gds-serverless[docs] for details on how to enable it.
 
-A GDS Session is in one of three flavours, determined by its data source:
+There are three types of GDS Sessions:
 
-* *Attached*, sourced from a Neo4j AuraDB instance.
-* *Self-managed*, sourced from a self-managed Neo4j DBMS.
-* *Standalone*, sourced from a non-Neo4j data source.
+* *Attached*: the data source is a Neo4j AuraDB instance.
+* *Self-managed*: the data source is a self-managed Neo4j DBMS.
+* *Standalone*: the data source is not based on Neo4j.
 
 
-We call the process of populating the session with data a _remote projection_.
+The process of populating the session with data is called _remote projection_.
 Once populated, a GDS Session can run GDS workloads, such as algorithms and machine learning models.
 Results from these computations can be written back to the original source, using _remote write-back_ in the Attached and Self-managed flavours.
 
@@ -49,7 +49,7 @@ PROJECT_ID = None
 sessions = GdsSessions(api_credentials=AuraAPICredentials(CLIENT_ID, CLIENT_SECRET, PROJECT_ID))
 ----
 
-All available methods and parameters are listed in our API https://neo4j.com/docs/graph-data-science-client/{docs-version}/api/sessions/gds_sessions/[reference].
+All available methods and parameters are listed in the https://neo4j.com/docs/graph-data-science-client/{docs-version}/api/sessions/gds_sessions/[API reference].
 
 
 === Creating a GDS Session
@@ -65,13 +65,13 @@ As a convention, always use the variable name `gds` for the return value of `get
 
 ==== Session expiration and deletion
 
-When the session is created, an optional `ttl` parameter can be configured, which specifies how quickly an inactive session will expire.
+When the session is created, an optional `ttl` parameter can be configured to set the time after which an inactive session will expire.
 The default value for `ttl` is 1 hour and the maximum allowed value is 7 days.
 An expired session cannot be used to run workloads, does not cost anything, and will be deleted automatically after 7 days.
 It can also be deleted through the Aura Console UI.
 
 
-===== Maximum lifetime
+==== Maximum lifetime
 
 A session can never be kept active for more than 7 days.
 Even if the session does not expire due to inactivity, it will still expire 7 days after its creation.

--- a/doc/modules/ROOT/pages/graph-analytics-serverless.adoc
+++ b/doc/modules/ROOT/pages/graph-analytics-serverless.adoc
@@ -93,15 +93,15 @@ sessions.get_or_create(
 ----
 
 .Parameters:
-[opts="header",cols="3m,1,1m,6", role="no-break"]
+[opts="header",cols="3m,1m,1,1m,6", role="no-break"]
 |===
-| Name                               | Optional | Default | Description
-| session_name                       | no       | -       | Name of the session. Must be unique within the project.
-| memory                             | no       | -       | Amount of memory available to the session. https://neo4j.com/docs/graph-data-science-client/{docs-version}/api/sessions/session_memory[Supported values].
-| db_connection                      | yes      | None    | Bolt server URL, username, and password to a Neo4j DBMS. Required for the Attached and Self-managed flavours.
-| ttl                                | yes      | 1h      | Time-to-live for the session.
-| cloud_location                     | yes      | None    | Aura-supported cloud provider and region where the GDS Session will run. Required for the Self-managed and Standalone flavours.
-| timeout                            | yes      | None    | Seconds to wait for the session to enter Ready state. If the time is exceeded, an error will be returned.
+| Name          | Type               | Optional | Default | Description
+| session_name  | str                | no       | -       | Name of the session. Must be unique within the project.
+| memory        | SessionMemory      | no       | -       | Amount of memory available to the session. https://neo4j.com/docs/graph-data-science-client/{docs-version}/api/sessions/session_memory[Supported values].
+| db_connection | DbmsConnectionInfo | yes      | None    | Bolt server URL, username, and password to a Neo4j DBMS. Required for the Attached and Self-managed flavours.
+| ttl           | datetime.timedelta | yes      | 1h      | Time-to-live for the session.
+| cloud_location| CloudLocation      | yes      | None    | Aura-supported cloud provider and region where the GDS Session will run. Required for the Self-managed and Standalone flavours.
+| timeout       | int                | yes      | None    | Seconds to wait for the session to enter Ready state. If the time is exceeded, an error will be returned.
 |===
 
 

--- a/doc/modules/ROOT/pages/graph-analytics-serverless.adoc
+++ b/doc/modules/ROOT/pages/graph-analytics-serverless.adoc
@@ -223,6 +223,9 @@ This operation is called _remote projection_ because the data source is not a co
 
 You can create a remote projection using the `gds.graph.project()` endpoint with a graph name, a Cypher query, and additional optional parameters.
 The Cypher query must contain the `gds.graph.project.remote()` function to project the graph into the GDS Session.
+This is only possible to do with Attached and self-managed sessions.
+Standalone sessions must use xref:graph-object.adoc#construct[graph.construct].
+
 
 === Syntax
 
@@ -232,22 +235,25 @@ The Cypher query must contain the `gds.graph.project.remote()` function to proje
 gds.graph.project(
     graph_name: str,
     query: str,
+    job_id: Optional[str] = None,
     concurrency: int = 4,
-    undirected_relationship_types: Optional[List[str]] = None,
-    inverse_indexed_relationship_types: Optional[List[str]] = None,
+    undirected_relationship_types: Optional[list[str]] = None,
+    inverse_indexed_relationship_types: Optional[list[str]] = None,
+    batch_size: Optional[int] = None,
 ): (Graph, Series[Any])
 ----
 
 .Parameters:
-[opts="header",cols="3m,1,1m,6", role="no-break"]
+[opts="header",cols="3m,1m,1,1m,6", role="no-break"]
 |===
-| Name                               | Optional | Default | Description
-| graph_name                         | no       | -       | Name of the graph.
-| query                              | no       | -       | Projection query.
-| concurrency                        | yes      | 4       | Concurrency to use for building the graph within the session.
-| batch_size                         | yes      | 10000   | Size of batches transmitted from the DBMS to the session.
-| undirected_relationship_types      | yes      | []      | List of relationship type names that should be treated as undirected.
-| inverse_indexed_relationship_types | yes      | []      | List of relationship type names that should be indexed in reverse.
+| Name                               | Type      | Optional | Default | Description
+| graph_name                         | str       | no       | -       | Name of the graph.
+| query                              | str       | no       | -       | Projection query.
+| job_id                             | str       | yes      | None    | Correlation id for the process on the session. If not provided an automatically generated id will be used.
+| concurrency                        | int       | yes      | 4       | Concurrency to use for building the graph within the session.
+| undirected_relationship_types      | list[str] | yes      | []      | List of relationship type names that should be treated as undirected.
+| inverse_indexed_relationship_types | list[str] | yes      | []      | List of relationship type names that should be indexed in reverse.
+| batch_size                         | int       | yes      | 10000   | Size of batches transmitted from the DBMS to the session.
 |===
 
 .Results:

--- a/doc/modules/ROOT/pages/graph-analytics-serverless.adoc
+++ b/doc/modules/ROOT/pages/graph-analytics-serverless.adoc
@@ -63,6 +63,21 @@ It offers a similar API to the `GraphDataScience` object, but it is configured t
 As a convention, always use the variable name `gds` for the return value of `get_or_create()`.
 
 
+==== Session expiration and deletion
+
+When the session is created, an optional `ttl` parameter can be configured, which specifies how quickly an inactive session will expire.
+The default value for `ttl` is 1 hour and the maximum allowed value is 7 days.
+An expired session cannot be used to run workloads, does not cost anything, and will be deleted automatically after 7 days.
+It can also be deleted through the Aura Console UI.
+
+
+===== Maximum lifetime
+
+A session can never be kept active for more than 7 days.
+Even if the session does not expire due to inactivity, it will still expire 7 days after its creation.
+This is a hard limit and cannot be changed.
+
+
 ==== Syntax
 
 [source, role=no-test]
@@ -88,33 +103,6 @@ sessions.get_or_create(
 | cloud_location                     | yes      | None    | Aura-supported cloud provider and region where the GDS Session will run. Required for the Self-managed and Standalone flavours.
 | timeout                            | yes      | None    | Seconds to wait for the session to enter Ready state. If the time is exceeded, an error will be returned.
 |===
-
-
-// To create a GDS Session, you need to provide the following information:
-//
-// - **Session name**.
-// The name must be unique.
-//
-// - **Session memory**.
-// This configuration determines the amount of memory and CPU available to the session.
-// It also determines the cost of running the session.
-// Available configurations are listed in our API https://neo4j.com/docs/graph-data-science-client/{docs-version}/api/sessions/session_memory[reference].
-// You can use the `sessions.estimate()` method to estimate the size required.
-// Available algorithm categories are listed in our API https://neo4j.com/docs/graph-data-science-client/{docs-version}/api/sessions/algorithm_category[reference].
-//
-// - **DBMS connection**.
-// This optional parameter is a `DbmsConnectionInfo` object that contains the URI of an Neo4j instance, a username, and a password. It is required if either a graph projection from a database or a write-back to a database is needed.
-// If not specified, graphs can be xref:graph-object.adoc#construct[constructed via arrow].
-//
-// - **TTL**.
-// This optional parameter specifies the time-to-live of the session.
-// The session will be automatically deleted if the session was unused for the provided duration.
-// Usage is defined as the computation of an algorithm or the projection of a graph.
-// By default, the session will be deleted after 1 hour of inactivity.
-//
-// - **Cloud location**.
-// This is a `CloudLocation` object that specifies the cloud provider and region where the GDS Session will run. Required if the DBMS connection is for a self-managed database.
-// Use `sessions.available_cloud_locations()` to find out which locations are available.
 
 
 ==== Examples

--- a/doc/modules/ROOT/pages/graph-analytics-serverless.adoc
+++ b/doc/modules/ROOT/pages/graph-analytics-serverless.adoc
@@ -119,51 +119,82 @@ sessions.get_or_create(
 
 ==== Examples
 
+.Creating GDS Sessions
+[.tabbed-example, caption = ]
+=====
+
+[.include-with-attached]
+=======
+
 .Creating a GDS Session for an AuraDB instance:
 [source,python,role=no-test]
 ----
 from datetime import timedelta
 from graphdatascience.session import DbmsConnectionInfo, AlgorithmCategory
 
-name = "my-new-session"
 memory = sessions.estimate(
     node_count=20,
     relationship_count=50,
     algorithm_categories=[AlgorithmCategory.CENTRALITY, AlgorithmCategory.NODE_EMBEDDING],
 )
-db_connection_info = DbmsConnectionInfo("neo4j+s://mydbid.databases.neo4j.io", "my-user", "my-password")
 
 gds = sessions.get_or_create(
-    session_name=name,
+    session_name="my-new-session",
     memory=memory,
-    db_connection=db_connection_info,
+    db_connection=DbmsConnectionInfo("neo4j+s://mydbid.databases.neo4j.io", "my-user", "my-password"),
     ttl=timedelta(hours=5),
 )
 ----
+=======
 
+[.include-with-self-Manged]
+=======
 .Creating a GDS Session for a self-managed Neo4j database:
 [source,python,role=no-test]
 ----
 from datetime import timedelta
 from graphdatascience.session import DbmsConnectionInfo, AlgorithmCategory, CloudLocation
 
-name = "my-new-session-sm"
 memory = sessions.estimate(
     node_count=20,
     relationship_count=50,
     algorithm_categories=[AlgorithmCategory.CENTRALITY, AlgorithmCategory.NODE_EMBEDDING],
 )
-db_connection_info = DbmsConnectionInfo("neo4j://localhost", "my-user", "my-password")
-cloud_location = CloudLocation(provider="gcp", region="europe-west1")
 
 gds = sessions.get_or_create(
-    session_name=name,
+    session_name="my-new-session-sm",
     memory=memory,
-    db_connection=db_connection_info,
-    ttl=timedelta(hours=5),
-    cloud_location=cloud_location,
+    db_connection=DbmsConnectionInfo("neo4j://localhost", "my-user", "my-password"),
+    ttl=timedelta(hours=2),
+    cloud_location=CloudLocation(provider="gcp", region="europe-west1"),
 )
 ----
+=======
+
+[.include-with-standalone]
+=======
+.Creating a GDS Session without any Neo4j database:
+[source,python,role=no-test]
+----
+from datetime import timedelta
+from graphdatascience.session import AlgorithmCategory, CloudLocation
+
+memory = sessions.estimate(
+    node_count=20,
+    relationship_count=50,
+    algorithm_categories=[AlgorithmCategory.CENTRALITY, AlgorithmCategory.NODE_EMBEDDING],
+)
+
+gds = sessions.get_or_create(
+    session_name="my-new-session-sm",
+    memory=memory,
+    ttl=timedelta(hours=2),
+    cloud_location=CloudLocation(provider="gcp", region="europe-west1"),
+)
+----
+=======
+
+=====
 
 
 === Listing GDS Sessions

--- a/doc/modules/ROOT/pages/graph-analytics-serverless.adoc
+++ b/doc/modules/ROOT/pages/graph-analytics-serverless.adoc
@@ -294,9 +294,17 @@ These have the same behavior as documented in the link:{neo4j-docs-base-uri}/gra
 This example shows how to project a graph into a GDS Session.
 The example graph is heterogeneous and models users and products.
 Users can know each other, and users can buy products.
-The database connection is to a new, empty AuraDB instance.
 
-.Create a GDS Session and add some data to the database:
+The Attached and Self-managed examples use a Cypher query to populate the database with the data.
+The Standalone example uses pandas DataFrames instead.
+
+[.tabbed-example, caption = ]
+=====
+
+[.include-with-attached]
+=======
+
+.Create some data in the Neo4j DBMS and project it to an Attached GDS Session:
 [source,python,role=no-test]
 ----
 import os # for reading environment variables
@@ -325,13 +333,7 @@ gds.run_cypher(
      (u1)-[:BOUGHT {price: 1337}]->(p2)
     """
 )
-----
 
-With the `gds` GDS Session active, project the graph and specify node and relationship property schemas as follows:
-
-.Project a graph into the GDS Session:
-[source,python,role=no-test]
-----
 G, result = gds.graph.project(
     graph_name="my-graph",
     query="""
@@ -355,6 +357,112 @@ G, result = gds.graph.project(
     """,
 )
 ----
+=======
+
+[.include-with-self-managed]
+=======
+.Create some data in the Neo4j DBMS and project it to a Self-managed GDS Session:
+[source,python,role=no-test]
+----
+import os # for reading environment variables
+from graphdatascience.session import SessionMemory, DbmsConnectionInfo, GdsSessions, AuraAPICredentials, CloudLocation
+
+sessions = GdsSessions(api_credentials=AuraAPICredentials(os.environ["CLIENT_ID"], os.environ["CLIENT_SECRET"]))
+
+db_connection = DbmsConnectionInfo(os.environ["DB_URI"], os.environ["DB_USER"], os.environ["DB_PASSWORD"])
+gds = sessions.get_or_create(
+    session_name="my-new-session",
+    memory=SessionMemory.m_8GB,
+    db_connection=db_connection,
+    cloud_location=CloudLocation(provider="gcp", region="europe-west1"),
+)
+
+gds.run_cypher(
+    """
+    CREATE
+     (u1:User {name: 'Mats'}),
+     (u2:User {name: 'Florentin'}),
+     (p1:Product {name: 'ice cream', cost: 4.2}),
+     (p2:Product {name: 'computer', cost: 13.37})
+
+    CREATE
+     (u1)-[:KNOWS {since: 2020}]->(u2),
+     (u2)-[:BOUGHT {price: 7474}]->(p1),
+     (u1)-[:BOUGHT {price: 1337}]->(p2)
+    """
+)
+
+G, result = gds.graph.project(
+    graph_name="my-graph",
+    query="""
+    CALL {
+        MATCH (u1:User)
+        OPTIONAL MATCH (u1)-[r:KNOWS]->(u2:User)
+        RETURN u1 AS source, r AS rel, u2 AS target, {} AS sourceNodeProperties, {} AS targetNodeProperties
+        UNION
+        MATCH (p:Product)
+        OPTIONAL MATCH (p)<-[r:BOUGHT]-(user:User)
+        RETURN user AS source, r AS rel, p AS target, {} AS sourceNodeProperties, {cost: p.cost} AS targetNodeProperties
+    }
+    RETURN gds.graph.project.remote(source, target, {
+      sourceNodeProperties: sourceNodeProperties,
+      targetNodeProperties: targetNodeProperties,
+      sourceNodeLabels: labels(source),
+      targetNodeLabels: labels(target),
+      relationshipType: type(rel),
+      relationshipProperties: properties(rel)
+    })
+    """,
+)
+----
+=======
+
+[.include-with-standalone]
+=======
+.Project some data to a Standalone GDS Session:
+[source,python,role=no-test]
+----
+from graphdatascience.session import CloudLocation, SessionMemory
+
+gds = sessions.get_or_create(
+    session_name="my-standalone-session",
+    memory=SessionMemory.m_4GB,
+    cloud_location=CloudLocation(provider="gcp", region="europe-west1"),
+)
+
+nodes = [pandas.DataFrame({
+        "nodeId": [0, 1],
+        "labels":  ["Person", "Person"],
+    }), pandas.DataFrame({
+        "nodeId": [2, 3],
+        "labels":  ["Product", "Product"],
+        "cost": [4.2, 13.37],
+    })
+]
+
+relationships = [pandas.DataFrame({
+        "sourceNodeId": [0],
+        "targetNodeId": [1],
+        "relationshipType": ["KNOWS"],
+        "since": [2020]
+    }), pandas.DataFrame({
+        "sourceNodeId": [0, 1],
+        "targetNodeId": [3, 2],
+        "relationshipType": ["BOUGHT", "BOUGHT"],
+        "price": [1337, 7474]
+    })
+]
+
+G = gds.graph.construct(
+    "my-graph",
+    nodes,
+    relationships
+)
+----
+=======
+
+=====
+
 
 
 == Running algorithms

--- a/doc/modules/ROOT/pages/graph-analytics-serverless.adoc
+++ b/doc/modules/ROOT/pages/graph-analytics-serverless.adoc
@@ -4,10 +4,7 @@
 
 Aura Graph Analytics Serverless is an on-demand ephemeral compute environment for running GDS workloads.
 Each compute unit is called a _GDS Session_.
-It is offered as part of link:https://neo4j.com/docs/aura/graph-analytics/[Neo4j Aura], a fast, scalable, always-on, fully automated cloud graph platform.
-
-NOTE: Aura Graph Analytics Serverless is not available by default.
-See the Aura https://neo4j.com/docs/aura/graph-analytics/#aura-gds-serverless[docs] for details on how to enable it.
+It is offered as part of link:https://neo4j.com/docs/aura/graph-analytics/#aura-gds-serverless[Neo4j Aura], a fast, scalable, always-on, fully automated cloud graph platform.
 
 There are three types of GDS Sessions:
 


### PR DESCRIPTION
- **Move serverless page upwards in TOC**
- **Add callout and quick example for serverless**
- **Introduce the three flavours**
- **Fix refdoc link**
- **Use a syntax table for `get_or_create`**
- **Make examples tabbed for creation**
- **Explain session expiration**
- **Simplify creation examples**
- **Add example for `estimate`**
- **Add type column to parameters table**
- **Improve syntax doc for graph.project**
- **Add tabbed examples for each flavour for graph projection**
- **Improve phrasing**
- **Remove note about disabled by default**
