### PR TITLE
Set liveness_check_timeout for AuraDB connection + allow custom config values

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,5 +12,7 @@
 ## Improvements
 
 * Allow creating sessions of size `512GB`.
+* Allow passing additional parameters for the Neo4j driver connection to `GdsSessions.get_or_create(neo4j_driver_config={..})`
+
 
 ## Other changes

--- a/graphdatascience/query_runner/neo4j_query_runner.py
+++ b/graphdatascience/query_runner/neo4j_query_runner.py
@@ -35,9 +35,13 @@ class Neo4jQueryRunner(QueryRunner):
         database: Optional[str] = None,
         bookmarks: Optional[Any] = None,
         show_progress: bool = True,
+        config: Optional[dict[str, Any]] = None,
     ) -> Neo4jQueryRunner:
         if isinstance(endpoint, str):
-            config: dict[str, Any] = {"user_agent": f"neo4j-graphdatascience-v{__version__}"}
+            if config is None:
+                config = {}
+
+            config["user_agent"] = f"neo4j-graphdatascience-v{__version__}"
 
             if aura_ds:
                 Neo4jQueryRunner._configure_aura(config)
@@ -100,9 +104,11 @@ class Neo4jQueryRunner(QueryRunner):
 
     @staticmethod
     def _configure_aura(config: dict[str, Any]) -> None:
-        config["max_connection_lifetime"] = 60 * 8  # 8 minutes
-        config["keep_alive"] = True
-        config["max_connection_pool_size"] = 50
+        # defaults as documented in https://support.neo4j.com/s/article/1500001173021-How-to-handle-Session-Expired-Errors-while-connecting-to-Neo4j-Aura
+        config.setdefault("max_connection_lifetime", 60 * 50)  # 50 minutes
+        config.setdefault("keep_alive", True)
+        config.setdefault("max_connection_pool_size", 50)
+        config.setdefault("liveness_check_timeout", 60 * 5)  # 5 minutes
 
     @staticmethod
     def parse_protocol(endpoint: str) -> str:

--- a/graphdatascience/query_runner/neo4j_query_runner.py
+++ b/graphdatascience/query_runner/neo4j_query_runner.py
@@ -108,7 +108,9 @@ class Neo4jQueryRunner(QueryRunner):
         config.setdefault("max_connection_lifetime", 60 * 50)  # 50 minutes
         config.setdefault("keep_alive", True)
         config.setdefault("max_connection_pool_size", 50)
-        config.setdefault("liveness_check_timeout", 60 * 5)  # 5 minutes
+
+        if Neo4jQueryRunner._NEO4J_DRIVER_VERSION >= SemanticVersion(5, 16, 0):
+            config.setdefault("liveness_check_timeout", 60 * 5)  # 5 minutes
 
     @staticmethod
     def parse_protocol(endpoint: str) -> str:

--- a/graphdatascience/session/gds_sessions.py
+++ b/graphdatascience/session/gds_sessions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Optional
+from typing import Any, Optional
 
 from graphdatascience.session.algorithm_category import AlgorithmCategory
 from graphdatascience.session.aura_api import AuraApi
@@ -90,6 +90,7 @@ class GdsSessions:
         ttl: Optional[timedelta] = None,
         cloud_location: Optional[CloudLocation] = None,
         timeout: Optional[int] = None,
+        neo4j_driver_config: Optional[dict[str, Any]] = None,
     ) -> AuraGraphDataScience:
         """
         Retrieves an existing session with the given session name and database connection,
@@ -105,12 +106,18 @@ class GdsSessions:
             ttl: (Optional[timedelta]): The sessions time to live after inactivity in seconds.
             cloud_location (Optional[CloudLocation]): The cloud location. Required if the GDS session is for a self-managed database.
             timeout (Optional[int]): Optional timeout (in seconds) when waiting for session to become ready. If unset the method will wait forever. If set and session does not become ready an exception will be raised. It is user responsibility to ensure resource gets cleaned up in this situation.
-
+            neo4j_driver_config (Optional[dict[str, Any]]): Optional configuration for the Neo4j driver.
         Returns:
             AuraGraphDataScience: The session.
         """
         return self._impl.get_or_create(
-            session_name, memory, db_connection=db_connection, ttl=ttl, cloud_location=cloud_location, timeout=timeout
+            session_name,
+            memory,
+            db_connection=db_connection,
+            ttl=ttl,
+            cloud_location=cloud_location,
+            timeout=timeout,
+            neo4j_driver_options=neo4j_driver_config,
         )
 
     def delete(self, *, session_name: Optional[str] = None, session_id: Optional[str] = None) -> bool:

--- a/graphdatascience/tests/unit/test_dedicated_sessions.py
+++ b/graphdatascience/tests/unit/test_dedicated_sessions.py
@@ -356,6 +356,7 @@ def test_create_attached_session(mocker: MockerFixture, aura_api: AuraApi) -> No
             "aura_ds": True,
             "database": None,
             "show_progress": False,
+            "config": None
         },
         "session_bolt_connection_info": DbmsConnectionInfo(
             uri="neo4j+s://foo.bar", username="client-id", password="client_secret"
@@ -399,6 +400,7 @@ def test_create_standalone_session(mocker: MockerFixture, aura_api: AuraApi) -> 
             "aura_ds": True,
             "database": None,
             "show_progress": False,
+            "config": None
         },
         "session_bolt_connection_info": DbmsConnectionInfo(
             uri="neo4j+s://foo.bar", username="client-id", password="client_secret"
@@ -446,6 +448,7 @@ def test_get_or_create(mocker: MockerFixture, aura_api: AuraApi) -> None:
             "aura_ds": True,
             "database": None,
             "show_progress": False,
+            "config": None
         },
         "session_bolt_connection_info": DbmsConnectionInfo(
             uri="neo4j+s://foo.bar", username="client-id", password="client_secret"

--- a/graphdatascience/tests/unit/test_dedicated_sessions.py
+++ b/graphdatascience/tests/unit/test_dedicated_sessions.py
@@ -356,7 +356,7 @@ def test_create_attached_session(mocker: MockerFixture, aura_api: AuraApi) -> No
             "aura_ds": True,
             "database": None,
             "show_progress": False,
-            "config": None
+            "config": None,
         },
         "session_bolt_connection_info": DbmsConnectionInfo(
             uri="neo4j+s://foo.bar", username="client-id", password="client_secret"
@@ -400,7 +400,7 @@ def test_create_standalone_session(mocker: MockerFixture, aura_api: AuraApi) -> 
             "aura_ds": True,
             "database": None,
             "show_progress": False,
-            "config": None
+            "config": None,
         },
         "session_bolt_connection_info": DbmsConnectionInfo(
             uri="neo4j+s://foo.bar", username="client-id", password="client_secret"
@@ -448,7 +448,7 @@ def test_get_or_create(mocker: MockerFixture, aura_api: AuraApi) -> None:
             "aura_ds": True,
             "database": None,
             "show_progress": False,
-            "config": None
+            "config": None,
         },
         "session_bolt_connection_info": DbmsConnectionInfo(
             uri="neo4j+s://foo.bar", username="client-id", password="client_secret"


### PR DESCRIPTION
As the user cannot pass the db driver connection directly, we offer they can pass driver options in get_or_create instead.
