### PR TITLE
Expose mode and retryable on user-facing run_cypher

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,8 +6,12 @@
 
 ## Bug fixes
 
-* Fix reporting error based on http responses from the Aura-API with an invalid JSON body. Earlier the client would report JSONDecodeError instead of showing the actual issue.
+- Fix reporting error based on http responses from the Aura-API with an invalid JSON body. Earlier the client would report JSONDecodeError instead of showing the actual issue.
 
 ## Improvements
+
+- `GraphDataScience::run_query` now supports setting the `mode` of the query to be used for routing. Previously queries would always route the leader of the cluster, assuming write mode.
+- `GraphDataScience::run_query` now support setting `retryable` to enable a retry-mechanism for appropriate errors. This requires `neo4j>=5.5.0`.
+
 
 ## Other changes

--- a/graphdatascience/graph/graph_cypher_runner.py
+++ b/graphdatascience/graph/graph_cypher_runner.py
@@ -6,6 +6,8 @@ from typing import Any, Optional
 
 from pandas import Series
 
+from graphdatascience.query_runner.query_mode import QueryMode
+
 from ..caller_base import CallerBase
 from ..query_runner.query_runner import QueryRunner
 from ..server_version.server_version import ServerVersion
@@ -46,7 +48,7 @@ class GraphCypherRunner(CallerBase):
         GraphCypherRunner._verify_query_ends_with_return_clause(self._namespace, query)
 
         result: Optional[dict[str, Any]] = self._query_runner.run_retryable_cypher(
-            query, params, database, custom_error=False
+            query, params, database, custom_error=False, mode=QueryMode.READ
         ).squeeze()
 
         if not result:

--- a/graphdatascience/graph/graph_entity_ops_runner.py
+++ b/graphdatascience/graph/graph_entity_ops_runner.py
@@ -5,6 +5,8 @@ from warnings import filterwarnings
 import pandas as pd
 from pandas import DataFrame, Series
 
+from graphdatascience.query_runner.query_mode import QueryMode
+
 from ..call_parameters import CallParameters
 from ..error.cypher_warning_handler import (
     filter_id_func_deprecation_warning,
@@ -164,7 +166,9 @@ class GraphNodePropertiesRunner(GraphEntityOpsBaseRunner):
             unique_node_ids = result["nodeId"].drop_duplicates().tolist()
 
             db_properties_df = query_runner.run_retryable_cypher(
-                GraphNodePropertiesRunner._build_query(db_node_properties), params={"ids": unique_node_ids}
+                GraphNodePropertiesRunner._build_query(db_node_properties),
+                params={"ids": unique_node_ids},
+                mode=QueryMode.READ,
             )
 
             if "propertyValue" not in result.keys():

--- a/graphdatascience/query_runner/arrow_query_runner.py
+++ b/graphdatascience/query_runner/arrow_query_runner.py
@@ -65,18 +65,22 @@ class ArrowQueryRunner(QueryRunner):
         query: str,
         params: Optional[dict[str, Any]] = None,
         database: Optional[str] = None,
+        mode: Optional[QueryMode] = None,
         custom_error: bool = True,
     ) -> DataFrame:
-        return self._fallback_query_runner.run_cypher(query, params, database, custom_error)
+        return self._fallback_query_runner.run_cypher(query, params, database, mode, custom_error=custom_error)
 
     def run_retryable_cypher(
         self,
         query: str,
         params: Optional[dict[str, Any]] = None,
         database: Optional[str] = None,
+        mode: Optional[QueryMode] = None,
         custom_error: bool = True,
     ) -> DataFrame:
-        return self._fallback_query_runner.run_retryable_cypher(query, params, database, custom_error=custom_error)
+        return self._fallback_query_runner.run_retryable_cypher(
+            query, params, database, mode, custom_error=custom_error
+        )
 
     def call_function(self, endpoint: str, params: Optional[CallParameters] = None) -> Any:
         return self._fallback_query_runner.call_function(endpoint, params)

--- a/graphdatascience/query_runner/cypher_graph_constructor.py
+++ b/graphdatascience/query_runner/cypher_graph_constructor.py
@@ -7,6 +7,8 @@ from uuid import uuid4
 
 from pandas import DataFrame, concat
 
+from graphdatascience.query_runner.query_mode import QueryMode
+
 from ..server_version.server_version import ServerVersion
 from .graph_constructor import GraphConstructor
 from .query_runner import QueryRunner
@@ -105,7 +107,9 @@ class CypherGraphConstructor(GraphConstructor):
     def _should_warn_about_arrow_missing(self) -> bool:
         try:
             license: str = self._query_runner.run_retryable_cypher(
-                "CALL gds.debug.sysInfo() YIELD key, value WHERE key = 'gdsEdition' RETURN value", custom_error=False
+                "CALL gds.debug.sysInfo() YIELD key, value WHERE key = 'gdsEdition' RETURN value",
+                custom_error=False,
+                mode=QueryMode.READ,
             ).squeeze()
             should_warn = license == "Licensed"
         except Exception as e:

--- a/graphdatascience/query_runner/query_mode.py
+++ b/graphdatascience/query_runner/query_mode.py
@@ -14,3 +14,11 @@ class QueryMode(str, Enum):
             return neo4j.RoutingControl.WRITE
         else:
             raise ValueError(f"Unknown query mode: {self}")
+
+    def neo4j_access_mode(self) -> str:
+        if self == QueryMode.READ:
+            return neo4j.READ_ACCESS
+        elif self == QueryMode.WRITE:
+            return neo4j.WRITE_ACCESS
+        else:
+            raise ValueError(f"Unknown query mode: {self}")

--- a/graphdatascience/query_runner/query_runner.py
+++ b/graphdatascience/query_runner/query_runner.py
@@ -35,6 +35,7 @@ class QueryRunner(ABC):
         query: str,
         params: Optional[dict[str, Any]] = None,
         database: Optional[str] = None,
+        mode: Optional[QueryMode] = None,
         custom_error: bool = True,
     ) -> DataFrame:
         pass
@@ -45,6 +46,7 @@ class QueryRunner(ABC):
         query: str,
         params: Optional[dict[str, Any]] = None,
         database: Optional[str] = None,
+        mode: Optional[QueryMode] = None,
         custom_error: bool = True,
     ) -> DataFrame:
         pass

--- a/graphdatascience/query_runner/session_query_runner.py
+++ b/graphdatascience/query_runner/session_query_runner.py
@@ -54,18 +54,20 @@ class SessionQueryRunner(QueryRunner):
         query: str,
         params: Optional[dict[str, Any]] = None,
         database: Optional[str] = None,
+        mode: Optional[QueryMode] = None,
         custom_error: bool = True,
     ) -> DataFrame:
-        return self._db_query_runner.run_cypher(query, params, database, custom_error)
+        return self._db_query_runner.run_cypher(query, params, database, mode, custom_error)
 
     def run_retryable_cypher(
         self,
         query: str,
         params: Optional[dict[str, Any]] = None,
         database: Optional[str] = None,
+        mode: Optional[QueryMode] = None,
         custom_error: bool = True,
     ) -> DataFrame:
-        return self._db_query_runner.run_retryable_cypher(query, params, database, custom_error=custom_error)
+        return self._db_query_runner.run_retryable_cypher(query, params, database, mode=mode, custom_error=custom_error)
 
     def call_function(self, endpoint: str, params: Optional[CallParameters] = None) -> Any:
         return self._gds_query_runner.call_function(endpoint, params)

--- a/graphdatascience/query_runner/standalone_session_query_runner.py
+++ b/graphdatascience/query_runner/standalone_session_query_runner.py
@@ -60,6 +60,7 @@ class StandaloneSessionQueryRunner(QueryRunner):
         query: str,
         params: Optional[dict[str, Any]] = None,
         database: Optional[str] = None,
+        mode: Optional[QueryMode] = None,
         custom_error: bool = True,
     ) -> DataFrame:
         raise NotImplementedError
@@ -69,6 +70,7 @@ class StandaloneSessionQueryRunner(QueryRunner):
         query: str,
         params: Optional[dict[str, Any]] = None,
         database: Optional[str] = None,
+        mode: Optional[QueryMode] = None,
         custom_error: bool = True,
     ) -> DataFrame:
         raise NotImplementedError

--- a/graphdatascience/session/dbms/protocol_resolver.py
+++ b/graphdatascience/session/dbms/protocol_resolver.py
@@ -3,6 +3,7 @@ from typing import Optional
 from neo4j.exceptions import Neo4jError
 
 from graphdatascience import QueryRunner
+from graphdatascience.query_runner.query_mode import QueryMode
 from graphdatascience.session.dbms.protocol_version import ProtocolVersion
 
 
@@ -37,7 +38,8 @@ class ProtocolVersionResolver:
         try:
             version_list = []
             for version_string in self._query_runner.run_retryable_cypher(
-                "CALL gds.session.dbms.protocol.version() YIELD version"
+                "CALL gds.session.dbms.protocol.version() YIELD version",
+                mode=QueryMode.READ,
             )["version"].to_list():
                 parsed_version = self._from_str(version_string)
                 if parsed_version:

--- a/graphdatascience/tests/integration/test_database_ops.py
+++ b/graphdatascience/tests/integration/test_database_ops.py
@@ -8,6 +8,7 @@ from neo4j import Driver
 from graphdatascience.graph_data_science import GraphDataScience
 from graphdatascience.query_runner.neo4j_query_runner import Neo4jQueryRunner
 from graphdatascience.query_runner.progress.static_progress_provider import StaticProgressProvider
+from graphdatascience.query_runner.query_mode import QueryMode
 from graphdatascience.tests.integration.conftest import AUTH, URI
 from graphdatascience.version import __version__
 
@@ -158,6 +159,11 @@ def test_aurads_accepts_neo4j_s() -> None:
 
 def test_run_cypher(gds: GraphDataScience) -> None:
     result = gds.run_cypher("CALL gds.list()")
+    assert len(result) > 10
+
+
+def test_run_read_cypher(gds: GraphDataScience) -> None:
+    result = gds.run_cypher("CALL gds.list()", mode=QueryMode.READ, retryable=True)
     assert len(result) > 10
 
 

--- a/graphdatascience/utils/direct_util_endpoints.py
+++ b/graphdatascience/utils/direct_util_endpoints.py
@@ -2,6 +2,8 @@ from typing import Any
 
 from pandas import DataFrame
 
+from graphdatascience.query_runner.query_mode import QueryMode
+
 from ..call_parameters import CallParameters
 from ..caller_base import CallerBase
 from ..error.client_only_endpoint import client_only_endpoint
@@ -48,7 +50,7 @@ class DirectUtilEndpoints(CallerBase):
         else:
             query = "MATCH (n) RETURN id(n) AS id"
 
-        node_match = self._query_runner.run_retryable_cypher(query, custom_error=False)
+        node_match = self._query_runner.run_retryable_cypher(query, custom_error=False, mode=QueryMode.READ)
 
         if len(node_match) != 1:
             raise ValueError(f"Filter did not match with exactly one node: {node_match}")

--- a/graphdatascience/utils/util_remote_proc_runner.py
+++ b/graphdatascience/utils/util_remote_proc_runner.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from graphdatascience.query_runner.query_mode import QueryMode
+
 from ..error.cypher_warning_handler import (
     filter_id_func_deprecation_warning,
 )
@@ -24,7 +26,7 @@ class UtilRemoteProcRunner(UncallableNamespace, IllegalAttrChecker):
         query = "MATCH (n) WHERE id(n) = $nodeId RETURN n"
         params = {"nodeId": node_id}
 
-        return self._query_runner.run_retryable_cypher(query=query, params=params).squeeze()
+        return self._query_runner.run_retryable_cypher(query=query, params=params, mode=QueryMode.READ).squeeze()
 
     @filter_id_func_deprecation_warning()
     def asNodes(self, node_ids: list[int]) -> list[Any]:
@@ -41,7 +43,7 @@ class UtilRemoteProcRunner(UncallableNamespace, IllegalAttrChecker):
         query = "MATCH (n) WHERE id(n) IN $nodeIds RETURN collect(n)"
         params = {"nodeIds": node_ids}
 
-        return self._query_runner.run_retryable_cypher(query=query, params=params).squeeze()  # type: ignore
+        return self._query_runner.run_retryable_cypher(query=query, params=params, mode=QueryMode.READ).squeeze()  # type: ignore
 
     @property
     def nodeProperty(self) -> NodePropertyFuncRunner:


### PR DESCRIPTION
seen in our e2e we now need to manually instantiate a neo4j driver to run retryable cypher queries such as for cleanup.
