### PR TITLE
Fixes issues in sphinx docs after dark mode added to docs

### DIFF
--- a/doc/sphinx/source/themes/neo4j/layout.html
+++ b/doc/sphinx/source/themes/neo4j/layout.html
@@ -12,7 +12,12 @@
 {% endblock %}
 
 {%- block content %}
-<body class="article docs sphinx">
+<body class="light-mode dark-mode article docs sphinx">
+<script>
+  const userColorSchemeName = 'neo4j-docs-theme';
+  const userColorScheme = localStorage.getItem(userColorSchemeName) || 'system';
+  document.documentElement.style.colorScheme = userColorScheme;
+</script>
 
 {%- block document %}
 

--- a/doc/sphinx/source/themes/neo4j/static/css/neo4j.css_t
+++ b/doc/sphinx/source/themes/neo4j/static/css/neo4j.css_t
@@ -157,6 +157,16 @@ div.code-block-caption:hover > a.headerlink {
     padding-bottom: 0.5rem;
 }
 
+.nav-menu .toctree-l{{ level }} a:hover,
+.nav-menu .toctree-l{{ level }} span:hover {
+    background: light-dark(var(--theme-light-color-neutral-hover), var(--theme-dark-color-primary-hover-weak));
+}
+
+.nav-menu .toctree-l{{ level }}>a.current {
+    background: light-dark(var(--theme-light-color-neutral-hover), var(--theme-dark-color-primary-hover-weak));
+    color: light-dark(var(--theme-light-color-primary-text), var(--theme-dark-color-primary-text));
+}
+
 .nav-menu .toctree-l{{ level }}>a.current::before {
     content: "";
     width: 4px;

--- a/doc/sphinx/source/themes/neo4j/static/css/neo4j.css_t
+++ b/doc/sphinx/source/themes/neo4j/static/css/neo4j.css_t
@@ -4,8 +4,8 @@ html.is-clipped--nav #searchbox {
     display: none !important;
 }
 
-body.sphinx .navbar-link a {
-    color: #3182ce;
+body .sphinxsidebar {
+    background: light-dark(var(--palette-neutral-15),var(--theme-dark-color-neutral-bg-weak));
 }
 
 body.sphinx .navbar-link a.external::after {
@@ -42,7 +42,6 @@ body.sphinx a.external::after {
 @media screen and (min-width: 1024px) {
 
     body.sphinx .toolbar {
-        background: initial;
         box-shadow: none;
         height: 0;
     }
@@ -63,15 +62,6 @@ body.sphinx a.external::after {
     body.sphinx .nav,
     body.sphinx .nav-panel-menu {
         height: auto;
-        background: initial;
-    }
-
-    body.sphinx .sphinxsidebar {
-        background: #f5f7fa;
-    }
-
-    body.sphinx .nav-panel-menu:not(.is-active)::after {
-        background: initial;
     }
 
     body.sphinx .navbar-start {
@@ -94,7 +84,6 @@ body.sphinx a.external::after {
 }
 
 .navbar-item, .navbar-link {
-    color: #4a5568;
     line-height: 1.8;
     padding: 0.5rem 1rem;
     position: relative;
@@ -114,7 +103,6 @@ body.sphinx a.external::after {
     flex-grow: 1;
 }
 .doc h1, .doc h2, .doc h3, .doc h4, .doc h5, .doc h6 {
-    color: #4a5568;
     font-weight: 400;
     -webkit-hyphens: none;
     -ms-hyphens: none;
@@ -169,16 +157,6 @@ div.code-block-caption:hover > a.headerlink {
     padding-bottom: 0.5rem;
 }
 
-.nav-menu .toctree-l{{ level }} a:hover,
-.nav-menu .toctree-l{{ level }} span:hover {
-    background-color: #e6e9ee;
-}
-
-.nav-menu .toctree-l{{ level }}>a.current {
-    background-color: #e6f8ff;
-    color: #0056b3;
-}
-
 .nav-menu .toctree-l{{ level }}>a.current::before {
     content: "";
     width: 4px;
@@ -186,7 +164,6 @@ div.code-block-caption:hover > a.headerlink {
     position: absolute;
     left: 0;
     top: 0;
-    background: #0056b3;
     border-radius: 4px;
 }
 
@@ -202,7 +179,6 @@ div.code-block-caption:hover > a.headerlink {
 }
 
 .nav-menu a, .nav-text {
-    color: #535b66;
     font-weight: 400;
     display: block;
     padding: 0.25rem 0;
@@ -231,9 +207,7 @@ body.sphinx .deprecated > *::after {
 
 body.sphinx .doc dl.deprecated dt:first-of-type span.sig-prename,
 body.sphinx .doc dl.deprecated dt:first-of-type span.sig-name {
-    border-bottom: 1px solid #f6ad55;
-    /* color: #702459; */
-    /* background-color: #fed7e2; */
+    border-bottom: 1px solid var(--palette-lemon-30);
 }
 
 body.sphinx .doc dl.deprecated {
@@ -244,7 +218,5 @@ body.sphinx .doc dl.deprecated {
 body.sphinx .doc div.deprecated {
     padding: 1rem;
     margin: 0 2rem;
-    /* color: #702459; */
-    border-left: 2px solid #f6ad55;
-    background-color: #fffaf0;
+    border-left: 2px solid var(--palette-lemon-30);
 }


### PR DESCRIPTION
Resolves some css conflicts after dark mode was added to docs. Removes almost all colors from this css, relying on defaults from the main site.css. The exception is `class="sphinxsidebar"` which does not exist outside of sphinx docs and has no value already defined.

Where colors are used, they use vards defined in needle design system. These vars are included in the main docs css that the sphinx theme imports.