### PR TITLE
Fix FutureWarning for empty Series

### DIFF
--- a/src/graphdatascience/graph/graph_remote_proc_runner.py
+++ b/src/graphdatascience/graph/graph_remote_proc_runner.py
@@ -62,7 +62,9 @@ class GraphRemoteProcRunner(BaseGraphProcRunner):
                 logging,
             )
 
-            return GraphCreateResult(Graph(graph_name, self._query_runner), pd.Series(result))
+            # explicitly specify empty dtype to avoid pandas 1.x FutureWarning
+            result_series = pd.Series(result) if result else pd.Series(result, dtype=object)
+            return GraphCreateResult(Graph(graph_name, self._query_runner), result_series)
 
         except Exception as e:
             handle_flight_error(e)


### PR DESCRIPTION
avoid following warning if used with pandas 1.x:
FutureWarning: The default dtype for empty Series will be 'object' instead of 'float64' in a future version. Specify a dtype explicitly to silence this warning.
