### PR TITLE
fix: reshape multi-property relationship stream result in v2 Cypher endpoint

### DIFF
--- a/src/graphdatascience/procedure_surface/cypher/catalog/relationship_cypher_endpoints.py
+++ b/src/graphdatascience/procedure_surface/cypher/catalog/relationship_cypher_endpoints.py
@@ -87,6 +87,15 @@ class RelationshipCypherEndpoints(RelationshipsEndpoints):
 
             if relationship_properties and len(relationship_properties) == 1:
                 result = result.rename(columns={"propertyValue": relationship_properties[0]})
+            elif relationship_properties and len(relationship_properties) > 1:
+                # Reshape the long-format Cypher result into one column per property to match the Arrow output.
+                result = result.pivot(
+                    index=["sourceNodeId", "targetNodeId", "relationshipType"],
+                    columns="relationshipProperty",
+                    values="propertyValue",
+                )
+                result = result.reset_index()
+                result.columns.name = None
 
             return result
 

--- a/tests/integrationV2/procedure_surface/cypher/catalog/test_relationship_cypher_endpoints.py
+++ b/tests/integrationV2/procedure_surface/cypher/catalog/test_relationship_cypher_endpoints.py
@@ -104,13 +104,13 @@ def test_stream_multiple_properties(relationship_endpoints: RelationshipCypherEn
         G=sample_graph, relationship_types=["REL"], relationship_properties=["weight", "weight2"]
     )
 
-    assert len(result) == 6  # All relationships
+    assert len(result) == 3  # All relationships
     assert "sourceNodeId" in result.columns
     assert "targetNodeId" in result.columns
     assert "relationshipType" in result.columns
-    assert "propertyValue" in result.columns
-    assert "relationshipProperty" in result.columns
-    assert set(result["relationshipProperty"].unique()) == {"weight", "weight2"}
+    assert "weight" in result.columns
+    assert "weight2" in result.columns
+    assert set(result["relationshipType"].unique()) == {"REL"}
 
 
 def test_stream_relationships_with_arrow(


### PR DESCRIPTION
The v2 relationship stream endpoint returned long-format results
(relationshipProperty/propertyValue columns) when called via Cypher
(gds without arrow) with multiple relationship properties, instead of
the wide format (one column per property) produced by the Arrow path.
Pivot the Cypher result to match the documented contract.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
