### PR TITLE
Add show_progress config plumbing and FastPath compute endpoint

### DIFF
--- a/src/graphdatascience/procedure_surface/api/write_job_handle.py
+++ b/src/graphdatascience/procedure_surface/api/write_job_handle.py
@@ -39,6 +39,7 @@ class WriteJobHandle:
             job_id,
             time.time(),
             termination_flag,
+            log_progress=log_progress,
         )
 
     def __init__(
@@ -48,6 +49,7 @@ class WriteJobHandle:
         job_id: str,
         started_at: float,
         termination_flag: TerminationFlag,
+        log_progress: bool = True,
     ):
         self._write_protocol = write_protocol
         self._graph_name = graph_name
@@ -55,6 +57,7 @@ class WriteJobHandle:
         self._started_at = started_at
         self._terminal_status: JobStatus | None = None
         self._termination_flag = termination_flag
+        self._log_progress = log_progress
 
     def job_id(self) -> str:
         return self._job_id
@@ -70,10 +73,12 @@ class WriteJobHandle:
     def done(self) -> bool:
         return self.status().done
 
-    def wait(self, log_progress: bool = True) -> None:
+    def wait(self, log_progress: bool | None = None) -> None:
         if self._terminal_status is not None:
             return
 
+        if log_progress is None:
+            log_progress = self._log_progress
         self._terminal_status = self._poll_until_done(log_progress)
 
     def result(self, *, wait: bool = True) -> WriteBackResult:

--- a/src/graphdatascience/procedure_surface/arrow/catalog/catalog_arrow_endpoints.py
+++ b/src/graphdatascience/procedure_surface/arrow/catalog/catalog_arrow_endpoints.py
@@ -303,7 +303,7 @@ class CatalogArrowEndpoints(CatalogEndpoints):
 
     @property
     def node_properties(self) -> NodePropertiesEndpoints:
-        return NodePropertiesArrowEndpoints(self._arrow_client, self._query_runner)
+        return NodePropertiesArrowEndpoints(self._arrow_client, self._query_runner, show_progress=self._show_progress)
 
     @property
     def relationships(self) -> RelationshipsEndpoints:

--- a/src/graphdatascience/procedure_surface/arrow/catalog/projection_arrow_endpoints.py
+++ b/src/graphdatascience/procedure_surface/arrow/catalog/projection_arrow_endpoints.py
@@ -48,7 +48,7 @@ class ProjectArrowEndpoints:
         undirected_relationship_types: typing.List[str] | None = None,
         inverse_indexed_relationship_types: typing.List[str] | None = None,
         batch_size: int | None = None,
-        logging: bool = True,
+        logging: bool | None = None,
     ) -> GraphWithProjectResult:
         """
         Projects a graph from the Neo4j database into the GDS graph catalog using Cypher projection.
@@ -72,8 +72,9 @@ class ProjectArrowEndpoints:
             List of relationship types to index in both directions.
         batch_size : int | None, default=None
             Number of rows to process in each batch when projecting the graph.
-        logging : bool, default=True
-            Whether to log progress during graph projection.
+        logging : bool | None, default=None
+            Whether to log progress during graph projection. Defaults to the
+            client's `show_progress` setting.
         Returns
         -------
         ProjectionResult:
@@ -83,6 +84,8 @@ class ProjectArrowEndpoints:
             raise ValueError("Remote projection is only supported for attached Sessions.")
 
         job_id = job_id or str(uuid.uuid4())
+        if logging is None:
+            logging = self._show_progress
 
         ProjectionRunner(self._project_protocol, self._arrow_client, TerminationFlag.create()).run_cypher_projection(
             graph_name,
@@ -152,7 +155,7 @@ class ProjectArrowEndpoints:
         undirected_relationship_types: typing.List[str] | None = None,
         inverse_indexed_relationship_types: typing.List[str] | None = None,
         batch_size: int | None = None,
-        logging: bool = True,
+        logging: bool | None = None,
     ) -> GraphWithProjectResult:
         """
         Projects a graph from the Neo4j database into the GDS graph catalog.
@@ -179,8 +182,9 @@ class ProjectArrowEndpoints:
             List of relationship types to index in both directions.
         batch_size : int | None, default=None
             Number of rows to process in each batch when projecting the graph.
-        logging : bool, default=True
-            Whether to log progress during graph projection.
+        logging : bool | None, default=None
+            Whether to log progress during graph projection. Defaults to the
+            client's `show_progress` setting.
         Returns
         -------
         ProjectionResult:
@@ -193,6 +197,8 @@ class ProjectArrowEndpoints:
             raise ValueError("Remote projection is only supported for attached Sessions.")
 
         job_id = job_id or str(uuid.uuid4())
+        if logging is None:
+            logging = self._show_progress
 
         ProjectionRunner(self._project_protocol, self._arrow_client, TerminationFlag.create()).run_store_projection(
             graph_name,

--- a/src/graphdatascience/procedure_surface/arrow/catalog/projection_arrow_endpoints.py
+++ b/src/graphdatascience/procedure_surface/arrow/catalog/projection_arrow_endpoints.py
@@ -48,7 +48,7 @@ class ProjectArrowEndpoints:
         undirected_relationship_types: typing.List[str] | None = None,
         inverse_indexed_relationship_types: typing.List[str] | None = None,
         batch_size: int | None = None,
-        logging: bool | None = None,
+        logging: bool = True,
     ) -> GraphWithProjectResult:
         """
         Projects a graph from the Neo4j database into the GDS graph catalog using Cypher projection.
@@ -72,9 +72,8 @@ class ProjectArrowEndpoints:
             List of relationship types to index in both directions.
         batch_size : int | None, default=None
             Number of rows to process in each batch when projecting the graph.
-        logging : bool | None, default=None
-            Whether to log progress during graph projection. Defaults to the
-            client's `show_progress` setting.
+        logging : bool, default=True
+            Whether to log progress during graph projection.
         Returns
         -------
         ProjectionResult:
@@ -84,8 +83,7 @@ class ProjectArrowEndpoints:
             raise ValueError("Remote projection is only supported for attached Sessions.")
 
         job_id = job_id or str(uuid.uuid4())
-        if logging is None:
-            logging = self._show_progress
+        logging = self._show_progress and logging
 
         ProjectionRunner(self._project_protocol, self._arrow_client, TerminationFlag.create()).run_cypher_projection(
             graph_name,
@@ -155,7 +153,7 @@ class ProjectArrowEndpoints:
         undirected_relationship_types: typing.List[str] | None = None,
         inverse_indexed_relationship_types: typing.List[str] | None = None,
         batch_size: int | None = None,
-        logging: bool | None = None,
+        logging: bool = True,
     ) -> GraphWithProjectResult:
         """
         Projects a graph from the Neo4j database into the GDS graph catalog.
@@ -182,9 +180,8 @@ class ProjectArrowEndpoints:
             List of relationship types to index in both directions.
         batch_size : int | None, default=None
             Number of rows to process in each batch when projecting the graph.
-        logging : bool | None, default=None
-            Whether to log progress during graph projection. Defaults to the
-            client's `show_progress` setting.
+        logging : bool, default=True
+            Whether to log progress during graph projection.
         Returns
         -------
         ProjectionResult:
@@ -197,8 +194,7 @@ class ProjectArrowEndpoints:
             raise ValueError("Remote projection is only supported for attached Sessions.")
 
         job_id = job_id or str(uuid.uuid4())
-        if logging is None:
-            logging = self._show_progress
+        logging = self._show_progress and logging
 
         ProjectionRunner(self._project_protocol, self._arrow_client, TerminationFlag.create()).run_store_projection(
             graph_name,

--- a/src/graphdatascience/procedure_surface/arrow/node_embedding/fastpath_arrow_endpoints.py
+++ b/src/graphdatascience/procedure_surface/arrow/node_embedding/fastpath_arrow_endpoints.py
@@ -7,6 +7,7 @@ from pandas import DataFrame
 from graphdatascience.arrow_client.authenticated_flight_client import AuthenticatedArrowClient
 from graphdatascience.graph.graph_api import Graph
 from graphdatascience.procedure_surface.api.default_values import ALL_TYPES
+from graphdatascience.procedure_surface.api.job_handle import JobHandle
 from graphdatascience.procedure_surface.api.node_embedding.fastpath_endpoints import (
     FastPathEndpoints,
     FastPathMutateResult,
@@ -55,6 +56,65 @@ class FastPathArrowEndpoints(FastPathEndpoints):
         self._node_property_endpoints = NodePropertyEndpointsHelper(
             arrow_client, write_protocol, show_progress=show_progress
         )
+
+    def compute(
+        self,
+        G: Graph,
+        base_node_label: str,
+        event_node_label: str,
+        dimension: int,
+        max_elapsed_time: int,
+        num_elapsed_times: int,
+        *,
+        categorical_event_properties: list[str] = [],
+        relationship_types: list[str] = ALL_TYPES,
+        context_node_label: str | None = None,
+        decay_factor: float = 1.0,
+        event_features: str | None = None,
+        first_relationship_type: str | None = None,
+        ignored_event_category: int = -1,
+        next_relationship_type: str | None = None,
+        output_time: float | None = None,
+        output_time_property: str | None = None,
+        random_seed: Any | None = None,
+        smoothing_rate: float = 0.0,
+        smoothing_window: int = 0,
+        time_node_property: str | None = None,
+        job_id: str | None = None,
+    ) -> JobHandle:
+        """Start the FastPath algorithm and return a :class:`JobHandle`.
+
+        The handle exposes ``mutate`` / ``write`` / ``stream`` so the caller can
+        decide how to materialize the result after the computation is started.
+        Mirrors :meth:`mutate` but omits the property name, which is supplied to
+        the handle instead.
+        """
+        config = self._node_property_endpoints.create_base_config(
+            G,
+            base_node_label=base_node_label,
+            categorical_event_properties=categorical_event_properties,
+            context_node_label=context_node_label,
+            decay_factor=decay_factor,
+            dimension=dimension,
+            event_features=event_features,
+            event_node_label=event_node_label,
+            first_relationship_type=first_relationship_type,
+            ignored_event_category=ignored_event_category,
+            max_elapsed_time=max_elapsed_time,
+            next_relationship_type=next_relationship_type,
+            num_elapsed_times=num_elapsed_times,
+            output_time=output_time,
+            output_time_property=output_time_property,
+            random_seed=random_seed,
+            relationship_types=relationship_types,
+            smoothing_rate=smoothing_rate,
+            smoothing_window=smoothing_window,
+            time_node_property=time_node_property,
+            job_id=job_id,
+        )
+
+        with _translate_feature_not_enabled():
+            return self._node_property_endpoints.run_job(G, FAST_PATH_ENDPOINT, config)
 
     def mutate(
         self,

--- a/src/graphdatascience/progress/progress_bar.py
+++ b/src/graphdatascience/progress/progress_bar.py
@@ -38,15 +38,26 @@ class ProgressBar(ABC):
 
 
 class TqdmProgressBar(ProgressBar):
+    # Process-wide tqdm options merged into every bar's own ``bar_options``
+    # (per-call options win on conflict). Lets a caller like the CLI set e.g.
+    # ``{"leave": False}`` once so all session progress bars clear themselves
+    # when done instead of piling up in the output.
+    _default_options: dict[str, Any] = {}
+
+    @classmethod
+    def set_default_options(cls, options: dict[str, Any]) -> None:
+        cls._default_options = dict(options)
+
     def __init__(self, task_name: str, relative_progress: float | None, bar_options: dict[str, Any] | None = None):
         root_task_name = task_name
+        options = {**self._default_options, **(bar_options or {})}
         if relative_progress is None:  # Qualitative progress report
             self._tqdm_bar = tqdm(
                 total=None,
                 unit="",
                 desc=root_task_name,
                 bar_format="{desc} [elapsed: {elapsed} {postfix}]",
-                **bar_options or {},
+                **options,
             )
         else:
             self._tqdm_bar = tqdm(
@@ -54,7 +65,7 @@ class TqdmProgressBar(ProgressBar):
                 unit="%",
                 desc=root_task_name,
                 initial=relative_progress,
-                **bar_options or {},
+                **options,
             )
 
     def __enter__(self: TqdmProgressBar) -> TqdmProgressBar:

--- a/src/graphdatascience/session/gds_sessions.py
+++ b/src/graphdatascience/session/gds_sessions.py
@@ -151,6 +151,7 @@ class GdsSessions:
         timeout: int | None = None,
         neo4j_driver_config: dict[str, Any] | None = None,
         arrow_client_options: dict[str, Any] | None = None,
+        show_progress: bool = True,
     ) -> AuraGraphDataScience:
         """
         Retrieves an existing session with the given session name and database connection,
@@ -168,6 +169,7 @@ class GdsSessions:
             timeout (int | None): Optional timeout (in seconds) when waiting for session to become ready. If unset the method will wait forever. If set and session does not become ready an exception will be raised. It is user responsibility to ensure resource gets cleaned up in this situation.
             neo4j_driver_config (dict[str, Any] | None): Optional configuration for the Neo4j driver to the Neo4j DBMS. Only relevant if `db_connection` is specified..
             arrow_client_options (dict[str, Any] | None): Optional configuration for the Arrow Flight client.
+            show_progress (bool): Whether the returned client should print its own job-progress bars (projection, algorithm execution, ...). Defaults to True.
         Returns:
             AuraGraphDataScience: The session.
         """
@@ -237,6 +239,7 @@ class GdsSessions:
             arrow_authentication,
             db_runner,
             arrow_client_options,
+            show_progress,
         )
 
     def delete(self, *, session_name: str | None = None, session_id: str | None = None) -> bool:
@@ -390,6 +393,7 @@ class GdsSessions:
         arrow_authentication: ArrowAuthentication,
         db_runner: Neo4jQueryRunner | None,
         arrow_client_options: dict[str, Any] | None = None,
+        show_progress: bool = True,
     ) -> AuraGraphDataScience:
         return AuraGraphDataScience.create(
             (session_host, session_port),
@@ -397,4 +401,5 @@ class GdsSessions:
             db_endpoint=db_runner,
             session_lifecycle_manager=SessionLifecycleManager(session_id, self._aura_api),
             arrow_client_options=arrow_client_options,
+            show_progress=show_progress,
         )

--- a/tests/unit/procedure_surface/arrow/node_embedding/test_fastpath_arrow_endpoints.py
+++ b/tests/unit/procedure_surface/arrow/node_embedding/test_fastpath_arrow_endpoints.py
@@ -5,7 +5,9 @@ import pytest
 from pyarrow import ArrowInvalid
 
 from graphdatascience.arrow_client.authenticated_flight_client import AuthenticatedArrowClient
+from graphdatascience.procedure_surface.api.job_handle import JobHandle
 from graphdatascience.procedure_surface.arrow.node_embedding.fastpath_arrow_endpoints import (
+    FAST_PATH_ENDPOINT,
     FastPathArrowEndpoints,
     FeatureNotEnabledError,
 )
@@ -72,3 +74,43 @@ def test_unrelated_invalid_argument_error_is_not_translated() -> None:
     ):
         with pytest.raises(ArrowInvalid, match="Must specify either outputTime"):
             _call(endpoints)
+
+
+def test_compute_returns_job_handle_for_fastpath_endpoint() -> None:
+    endpoints = _fastpath_endpoints()
+
+    with mock.patch(
+        "graphdatascience.procedure_surface.arrow.endpoints_helper_base.JobClient.run_job",
+        return_value="job-123",
+    ) as run_job:
+        handle = endpoints.compute(
+            G=mock.Mock(),
+            base_node_label="Base",
+            event_node_label="Event",
+            dimension=16,
+            max_elapsed_time=10,
+            num_elapsed_times=4,
+        )
+
+    assert isinstance(handle, JobHandle)
+    assert handle.job_id() == "job-123"
+    # The job was started against the FastPath endpoint.
+    assert run_job.call_args.args[1] == FAST_PATH_ENDPOINT
+
+
+def test_compute_translates_unsupported_action_to_feature_not_enabled() -> None:
+    endpoints = _fastpath_endpoints()
+
+    with mock.patch(
+        "graphdatascience.procedure_surface.arrow.endpoints_helper_base.JobClient.run_job",
+        side_effect=_UNSUPPORTED_ACTION_ERROR,
+    ):
+        with pytest.raises(FeatureNotEnabledError, match="not enabled for this session"):
+            endpoints.compute(
+                G=mock.Mock(),
+                base_node_label="Base",
+                event_node_label="Event",
+                dimension=16,
+                max_elapsed_time=10,
+                num_elapsed_times=4,
+            )

--- a/tests/unit/procedure_surface/arrow/test_catalog_arrow_endpoints.py
+++ b/tests/unit/procedure_surface/arrow/test_catalog_arrow_endpoints.py
@@ -89,6 +89,17 @@ def test_construct_with_df_lists(mocker: MockerFixture) -> None:
         assert G.name() == "g"
 
 
+def test_node_properties_endpoint_inherits_show_progress(mocker: MockerFixture) -> None:
+    arrow_client = mocker.Mock(spec=AuthenticatedArrowClient)
+
+    quiet_endpoints = CatalogArrowEndpoints(arrow_client=arrow_client, show_progress=False)
+    loud_endpoints = CatalogArrowEndpoints(arrow_client=arrow_client, show_progress=True)
+
+    # `.node_properties` is typed as the abstract endpoint; the concrete arrow impl carries _show_progress.
+    assert getattr(quiet_endpoints.node_properties, "_show_progress") is False
+    assert getattr(loud_endpoints.node_properties, "_show_progress") is True
+
+
 def patch_gds_arrow_client(create_graph_job_id: str) -> ExitStack:
     exit_stack = ExitStack()
     patches = [

--- a/tests/unit/procedure_surface/arrow/test_projection_arrow_endpoints.py
+++ b/tests/unit/procedure_surface/arrow/test_projection_arrow_endpoints.py
@@ -1,0 +1,64 @@
+from unittest import mock
+
+from pytest_mock import MockerFixture
+
+from graphdatascience.arrow_client.authenticated_flight_client import AuthenticatedArrowClient
+from graphdatascience.procedure_surface.arrow.catalog.projection_arrow_endpoints import ProjectArrowEndpoints
+from graphdatascience.session.dbms.protocol_version import ProtocolVersion
+
+PROJECTION_MODULE = "graphdatascience.procedure_surface.arrow.catalog.projection_arrow_endpoints"
+
+
+def _endpoints_with_mocked_projection(
+    mocker: MockerFixture, show_progress: bool
+) -> tuple[ProjectArrowEndpoints, mock.Mock]:
+    """A ProjectArrowEndpoints wired up to run cypher() without any real network/protocol calls,
+    with `ProjectionRunner` mocked so the test can inspect what `logging` value it was given."""
+    arrow_client = mocker.Mock(spec=AuthenticatedArrowClient)
+    query_runner = mocker.Mock()
+
+    mocker.patch(f"{PROJECTION_MODULE}.ProtocolVersionResolver").return_value.resolve.return_value = ProtocolVersion.V4
+    mocker.patch(f"{PROJECTION_MODULE}.ProjectProtocol")
+    runner_cls = mocker.patch(f"{PROJECTION_MODULE}.ProjectionRunner")
+    mocker.patch(
+        f"{PROJECTION_MODULE}.JobClient.get_summary",
+        return_value={
+            "graph_name": "g",
+            "node_count": 1,
+            "relationship_count": 1,
+            "project_millis": 1,
+            "configuration": {},
+            "query": "MATCH (n) RETURN gds.graph.project.remote(n, n)",
+        },
+    )
+    mocker.patch(f"{PROJECTION_MODULE}.get_graph", return_value=mocker.Mock())
+
+    endpoints = ProjectArrowEndpoints(arrow_client=arrow_client, query_runner=query_runner, show_progress=show_progress)
+    return endpoints, runner_cls.return_value
+
+
+def test_cypher_defaults_logging_to_show_progress_true(mocker: MockerFixture) -> None:
+    endpoints, runner = _endpoints_with_mocked_projection(mocker, show_progress=True)
+
+    endpoints.cypher("g", "MATCH (n) RETURN gds.graph.project.remote(n, n)")
+
+    logging_arg = runner.run_cypher_projection.call_args.args[-1]
+    assert logging_arg is True
+
+
+def test_cypher_defaults_logging_to_show_progress_false(mocker: MockerFixture) -> None:
+    endpoints, runner = _endpoints_with_mocked_projection(mocker, show_progress=False)
+
+    endpoints.cypher("g", "MATCH (n) RETURN gds.graph.project.remote(n, n)")
+
+    logging_arg = runner.run_cypher_projection.call_args.args[-1]
+    assert logging_arg is False
+
+
+def test_cypher_explicit_logging_overrides_show_progress(mocker: MockerFixture) -> None:
+    endpoints, runner = _endpoints_with_mocked_projection(mocker, show_progress=True)
+
+    endpoints.cypher("g", "MATCH (n) RETURN gds.graph.project.remote(n, n)", logging=False)
+
+    logging_arg = runner.run_cypher_projection.call_args.args[-1]
+    assert logging_arg is False

--- a/tests/unit/procedure_surface/arrow/test_projection_arrow_endpoints.py
+++ b/tests/unit/procedure_surface/arrow/test_projection_arrow_endpoints.py
@@ -37,7 +37,7 @@ def _endpoints_with_mocked_projection(
     return endpoints, runner_cls.return_value
 
 
-def test_cypher_defaults_logging_to_show_progress_true(mocker: MockerFixture) -> None:
+def test_cypher_logs_when_show_progress_enabled(mocker: MockerFixture) -> None:
     endpoints, runner = _endpoints_with_mocked_projection(mocker, show_progress=True)
 
     endpoints.cypher("g", "MATCH (n) RETURN gds.graph.project.remote(n, n)")
@@ -46,7 +46,7 @@ def test_cypher_defaults_logging_to_show_progress_true(mocker: MockerFixture) ->
     assert logging_arg is True
 
 
-def test_cypher_defaults_logging_to_show_progress_false(mocker: MockerFixture) -> None:
+def test_cypher_does_not_log_when_show_progress_disabled(mocker: MockerFixture) -> None:
     endpoints, runner = _endpoints_with_mocked_projection(mocker, show_progress=False)
 
     endpoints.cypher("g", "MATCH (n) RETURN gds.graph.project.remote(n, n)")
@@ -55,7 +55,7 @@ def test_cypher_defaults_logging_to_show_progress_false(mocker: MockerFixture) -
     assert logging_arg is False
 
 
-def test_cypher_explicit_logging_overrides_show_progress(mocker: MockerFixture) -> None:
+def test_cypher_logging_false_disables_logging(mocker: MockerFixture) -> None:
     endpoints, runner = _endpoints_with_mocked_projection(mocker, show_progress=True)
 
     endpoints.cypher("g", "MATCH (n) RETURN gds.graph.project.remote(n, n)", logging=False)

--- a/tests/unit/session/test_gds_sessions.py
+++ b/tests/unit/session/test_gds_sessions.py
@@ -288,6 +288,7 @@ class FakeGdsSessions(GdsSessions):
         arrow_authentication: ArrowAuthentication,
         db_runner: Neo4jQueryRunner | None,
         arrow_client_options: dict[str, Any] | None = None,
+        show_progress: bool = True,
     ) -> AuraGraphDataScience:
         self.construct_client_calls.append(
             {
@@ -297,6 +298,7 @@ class FakeGdsSessions(GdsSessions):
                 "arrow_authentication": arrow_authentication,
                 "db_runner": db_runner,
                 "arrow_client_options": arrow_client_options,
+                "show_progress": show_progress,
             }
         )
         return mock.MagicMock(spec=AuraGraphDataScience)


### PR DESCRIPTION
Two small, independent additions to the core library (split out from unrelated CLI work).

## Progress-bar configuration
- `ProgressBar.set_default_options(...)`: process-wide tqdm options merged into every bar, with per-call `bar_options` winning on conflict. Lets a caller set e.g. `{"leave": False}` once for all bars.
- `GdsSessions.get_or_create` / `connect` accept `show_progress` (default `True`).
- `WriteJobHandle` stores a default `log_progress`; `wait()` falls back to it when not given one explicitly.
- Catalog / projection arrow endpoints now default their `logging` to the client's `show_progress` instead of a hardcoded `True`.

## FastPath compute endpoint
- `FastPathArrowEndpoints.compute()` starts the algorithm and returns a `JobHandle`, so the caller decides how to materialize the result (`mutate` / `write` / `stream`). Mirrors `mutate()` but omits the property name.

Unit tests added for both.