### PR TITLE
DOCOPS-176 Add page-tabs attributes to publish playbook

### DIFF
--- a/doc/publish.yml
+++ b/doc/publish.yml
@@ -38,6 +38,8 @@ asciidoc:
   - "@neo4j-documentation/macros"
   - "@neo4j-antora/mark-terms"
   attributes:
+    page-tabs: tools@
+    page-tabs-index: 80
     page-theme: docs
     page-type: Docs
     page-search-type: Docs


### PR DESCRIPTION
Adds `page-tabs` and `page-tabs-index` to `doc/publish.yml`:

```yaml
page-tabs: tools@
page-tabs-index: 80
```

Places this docset in the `tools` tab of the aggregated tabbed navigation, at the
position matching its order in the Docs menu on neo4j.com/docs. The value is
soft-set with a trailing `@` so it can be overridden.
