### PR TITLE
Mark as prerelease, add to publish playbook

### DIFF
--- a/doc/antora.yml
+++ b/doc/antora.yml
@@ -1,6 +1,7 @@
 name: graph-data-science-client
 title: Neo4j Graph Data Science Client
-version: '2.0'
+version: '2.0-preview'
+prerelease: true
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc

--- a/doc/publish.yml
+++ b/doc/publish.yml
@@ -10,7 +10,7 @@ content:
     start_path: doc
     # Includes previous version and current.
     # Does not include preview (main) as it is no longer necessary.
-    branches: ['1.19', '1.20', '1.21', '1.22']
+    branches: ['1.19', '1.20', '1.21', '1.22', 'HEAD']
     include: doc/
     exclude:
     - '!**/_includes/*'


### PR DESCRIPTION
Adds preview docs for the next version to the publish playbook.

The version name is appended with `-preview` so that extensions and CI (for example, sitemap generation and `/current/` version mapping) disregard the version.