### PR TITLE
Fix inverted neo4j.notifications log filters

### DIFF
--- a/src/graphdatascience/query_runner/neo4j_query_runner.py
+++ b/src/graphdatascience/query_runner/neo4j_query_runner.py
@@ -22,10 +22,19 @@ from graphdatascience.version import __version__
 from graphdatascience.versions import SemanticVersion, ServerVersion
 
 
+def _skip_gds_deprecated_field(record: logging.LogRecord) -> bool:
+    return not ("The query used a deprecated field from a procedure" in record.msg and "by 'gds." in record.msg)
+
+
+def _skip_gds_deprecated_procedure(record: logging.LogRecord) -> bool:
+    return not ("The procedure has a deprecated field" in record.msg and "gds." in record.msg)
+
+
 class Neo4jQueryRunner(QueryRunner):
     _AURA_DS_PROTOCOL = "neo4j+s"
     _LOG_POLLING_INTERVAL = 0.5
     _NEO4J_DRIVER_VERSION = SemanticVersion.from_string(neo4j.__version__)
+    _warnings_filters_configured = False
 
     @staticmethod
     def create_for_db(
@@ -448,14 +457,13 @@ class Neo4jQueryRunner(QueryRunner):
     def __configure_warnings_filter(self) -> None:
         notifications_logger = logging.getLogger("neo4j.notifications")
         # the client does not expose YIELD fields so we just skip these warnings for now
-        notifications_logger.addFilter(
-            lambda record: (
-                "The query used a deprecated field from a procedure" in record.msg and "by 'gds." in record.msg
-            )
-        )
-        notifications_logger.addFilter(
-            lambda record: "The procedure has a deprecated field" in record.msg and "gds." in record.msg
-        )
+        if _skip_gds_deprecated_field not in notifications_logger.filters:
+            notifications_logger.addFilter(_skip_gds_deprecated_field)
+        if _skip_gds_deprecated_procedure not in notifications_logger.filters:
+            notifications_logger.addFilter(_skip_gds_deprecated_procedure)
+
+        if Neo4jQueryRunner._warnings_filters_configured:
+            return
         warnings.filterwarnings(
             "ignore",
             message=r"^pandas support is experimental and might be changed or removed in future versions$",
@@ -465,6 +473,7 @@ class Neo4jQueryRunner(QueryRunner):
         # neo4j driver 6.0
         warnings.filterwarnings("ignore", message=r".*returned by the procedure.* is deprecated.*")
         warnings.filterwarnings("ignore", message=r".*procedure field deprecated..*")
+        Neo4jQueryRunner._warnings_filters_configured = True
 
     def _wrap_query(self, query: str, query_type: QueryType) -> neo4j.Query:
         return neo4j.Query(

--- a/tests/unit/query_runner/test_neo4j_query_runner_warnings_filter.py
+++ b/tests/unit/query_runner/test_neo4j_query_runner_warnings_filter.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import logging
+from typing import Generator
+from unittest.mock import Mock
+
+import pytest
+
+from graphdatascience.query_runner.neo4j_query_runner import Neo4jQueryRunner
+
+
+@pytest.fixture
+def clean_notifications_logger() -> Generator[logging.Logger, None, None]:
+    logger = logging.getLogger("neo4j.notifications")
+    original_filters = list(logger.filters)
+    original_flag = getattr(Neo4jQueryRunner, "_warnings_filters_configured", False)
+    try:
+        yield logger
+    finally:
+        logger.filters = original_filters
+        Neo4jQueryRunner._warnings_filters_configured = original_flag
+
+
+def _make_record(msg: str) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="neo4j.notifications",
+        level=logging.WARNING,
+        pathname=__file__,
+        lineno=1,
+        msg=msg,
+        args=(),
+        exc_info=None,
+    )
+
+
+def _configure(runner: Neo4jQueryRunner) -> None:
+    runner._Neo4jQueryRunner__configure_warnings_filter()  # type: ignore[attr-defined]
+
+
+def test_unrelated_notifications_are_kept(clean_notifications_logger: logging.Logger) -> None:
+    runner = Neo4jQueryRunner(driver=Mock(), protocol="bolt")
+    _configure(runner)
+
+    unrelated_record = _make_record("Some unrelated neo4j notification")
+    assert clean_notifications_logger.filter(unrelated_record)
+
+
+def test_configure_warnings_filter_is_idempotent(clean_notifications_logger: logging.Logger) -> None:
+    runner = Neo4jQueryRunner(driver=Mock(), protocol="bolt")
+    _configure(runner)
+    count_after_first = len(clean_notifications_logger.filters)
+    _configure(runner)
+    count_after_second = len(clean_notifications_logger.filters)
+    assert count_after_second == count_after_first
+
+
+def test_gds_deprecated_field_notification_is_dropped(clean_notifications_logger: logging.Logger) -> None:
+    runner = Neo4jQueryRunner(driver=Mock(), protocol="bolt")
+    _configure(runner)
+
+    deprecated_record = _make_record(
+        "The query used a deprecated field from a procedure 'gds.pageRank.stream' by 'gds.pagerank.stream'"
+    )
+    assert not clean_notifications_logger.filter(deprecated_record)
+
+
+def test_gds_deprecated_procedure_notification_is_dropped(
+    clean_notifications_logger: logging.Logger,
+) -> None:
+    runner = Neo4jQueryRunner(driver=Mock(), protocol="bolt")
+    _configure(runner)
+
+    deprecated_record = _make_record("The procedure has a deprecated field 'foo' returned by the procedure 'gds.bar'")
+    assert not clean_notifications_logger.filter(deprecated_record)


### PR DESCRIPTION
The two logging filters in __configure_warnings_filter were inverted: a
filter keeps records when it returns truthy, but the lambdas returned True
for exactly the GDS deprecated-field messages they intended to suppress,
and False for everything else. This caused unrelated Neo4j notifications
to be silently dropped while the targeted warnings were still logged.

The filters were also re-registered on every run_cypher call, growing the
logger and warnings filter lists unboundedly.

The lambdas are replaced with named negated filter functions, and
registration is made idempotent (membership check for logger filters,
class-level flag for warnings filters).
