### PR TITLE
Fix Arrow write helper result key and clarify Bellman-Ford config

### DIFF
--- a/src/graphdatascience/procedure_surface/api/node_embedding/fastpath_endpoints.py
+++ b/src/graphdatascience/procedure_surface/api/node_embedding/fastpath_endpoints.py
@@ -285,5 +285,5 @@ class FastPathWriteResult(BaseResult):
     pre_processing_millis: int
     compute_millis: int = Field(alias="predict_ms")
     write_millis: int
-    node_properties_written: int = Field(alias="propertiesWritten")
+    node_properties_written: int
     configuration: dict[str, Any]

--- a/src/graphdatascience/procedure_surface/arrow/centrality/articulationpoints_arrow_endpoints.py
+++ b/src/graphdatascience/procedure_surface/arrow/centrality/articulationpoints_arrow_endpoints.py
@@ -161,9 +161,6 @@ class ArticulationPointsArrowEndpoints(ArticulationPointsEndpoints):
             concurrency=concurrency,
         )
 
-        if "propertiesWritten" in result:
-            result["nodePropertiesWritten"] = result.pop("propertiesWritten")
-
         return ArticulationPointsWriteResult(**result)
 
     def estimate(

--- a/src/graphdatascience/procedure_surface/arrow/endpoints_helper_base.py
+++ b/src/graphdatascience/procedure_surface/arrow/endpoints_helper_base.py
@@ -118,8 +118,8 @@ class EndpointsHelperBase:
 
         if relationship_type_overwrite:
             computation_result["relationshipsWritten"] = write_result.written_relationships
-        if property_overwrites:
-            computation_result["propertiesWritten"] = write_result.written_node_properties
+        if property_overwrites and not relationship_type_overwrite:
+            computation_result["nodePropertiesWritten"] = write_result.written_node_properties
 
         return computation_result
 

--- a/src/graphdatascience/procedure_surface/arrow/pathfinding/single_source_bellman_ford_arrow_endpoints.py
+++ b/src/graphdatascience/procedure_surface/arrow/pathfinding/single_source_bellman_ford_arrow_endpoints.py
@@ -138,6 +138,8 @@ class BellmanFordArrowEndpoints(SingleSourceBellmanFordEndpoints):
         config = self._endpoints_helper.create_base_config(
             G,
             sourceNode=source_node,
+            # The Arrow v2 endpoint uses writeNegativeCycles for both mutate and write modes,
+            # unlike the Cypher procedure which uses mutateNegativeCycles for mutate.
             writeNegativeCycles=mutate_negative_cycles,
             relationshipWeightProperty=relationship_weight_property,
             relationshipTypes=relationship_types,

--- a/tests/unit/procedure_surface/arrow/test_endpoints_helper_base.py
+++ b/tests/unit/procedure_surface/arrow/test_endpoints_helper_base.py
@@ -1,0 +1,116 @@
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from graphdatascience.arrow_client.authenticated_flight_client import AuthenticatedArrowClient
+from graphdatascience.procedure_surface.api.write_job_handle import WriteBackResult
+from graphdatascience.procedure_surface.arrow.endpoints_helper_base import EndpointsHelperBase
+from graphdatascience.session.remote_ops.write_protocols import WriteProtocol
+
+
+@pytest.fixture
+def helper() -> EndpointsHelperBase:
+    arrow_client = mock.Mock(spec=AuthenticatedArrowClient)
+    write_protocol = mock.Mock(spec=WriteProtocol)
+    return EndpointsHelperBase(arrow_client, write_protocol=write_protocol, show_progress=False)
+
+
+def _make_write_result(node_props: int = 5) -> WriteBackResult:
+    return WriteBackResult(
+        writtenNodeProperties=node_props,
+        writtenNodeLabels=0,
+        writtenRelationships=0,
+        writeMillis=10,
+        status="COMPLETED",
+        progress=1.0,
+    )
+
+
+def test_run_job_and_write_uses_nodePropertiesWritten_key(helper: EndpointsHelperBase) -> None:
+    graph = mock.Mock()
+    graph.name.return_value = "g"
+
+    fake_summary: dict[str, Any] = {
+        "computeMillis": 1,
+        "configuration": {},
+    }
+
+    with (
+        mock.patch(
+            "graphdatascience.procedure_surface.arrow.endpoints_helper_base.JobClient.run_job_and_wait",
+            return_value="job-1",
+        ),
+        mock.patch(
+            "graphdatascience.procedure_surface.arrow.endpoints_helper_base.JobClient.get_summary",
+            return_value=fake_summary,
+        ),
+        mock.patch(
+            "graphdatascience.procedure_surface.arrow.endpoints_helper_base.WriteJobHandle.create"
+        ) as mock_create,
+    ):
+        mock_handle = mock_create.return_value
+        mock_handle.result.return_value = _make_write_result(node_props=7)
+
+        result = helper._run_job_and_write(
+            "v2/centrality.pageRank",
+            graph,
+            {"graphName": "g"},
+            property_overwrites="score",
+            write_concurrency=4,
+            concurrency=None,
+        )
+
+    assert "nodePropertiesWritten" in result
+    assert result["nodePropertiesWritten"] == 7
+    assert "propertiesWritten" not in result
+
+
+def test_run_job_and_write_relationship_property_does_not_set_nodePropertiesWritten(
+    helper: EndpointsHelperBase,
+) -> None:
+    graph = mock.Mock()
+    graph.name.return_value = "g"
+
+    fake_summary: dict[str, Any] = {
+        "computeMillis": 1,
+        "configuration": {},
+    }
+
+    with (
+        mock.patch(
+            "graphdatascience.procedure_surface.arrow.endpoints_helper_base.JobClient.run_job_and_wait",
+            return_value="job-1",
+        ),
+        mock.patch(
+            "graphdatascience.procedure_surface.arrow.endpoints_helper_base.JobClient.get_summary",
+            return_value=fake_summary,
+        ),
+        mock.patch(
+            "graphdatascience.procedure_surface.arrow.endpoints_helper_base.WriteJobHandle.create"
+        ) as mock_create,
+    ):
+        mock_handle = mock_create.return_value
+        mock_handle.result.return_value = WriteBackResult(
+            writtenNodeProperties=0,
+            writtenNodeLabels=0,
+            writtenRelationships=3,
+            writeMillis=10,
+            status="COMPLETED",
+            progress=1.0,
+        )
+
+        result = helper._run_job_and_write(
+            "v2/pathfinding.maxFlow",
+            graph,
+            {"graphName": "g"},
+            relationship_type_overwrite="FLOW",
+            property_overwrites="cost",
+            write_concurrency=4,
+            concurrency=None,
+        )
+
+    assert "relationshipsWritten" in result
+    assert result["relationshipsWritten"] == 3
+    assert "nodePropertiesWritten" not in result
+    assert "propertiesWritten" not in result


### PR DESCRIPTION
The _run_job_and_write helper emitted propertiesWritten but all
algorithm *WriteResult models expect nodePropertiesWritten (via the
pydantic alias). This caused validation failures on write-back endpoints;
only articulation points had a local workaround, which is now removed.

The nodePropertiesWritten key is only set for node-property writes
(when relationship_type_overwrite is not set), since relationship-
writing algorithms (e.g. Max Flow, Steiner Tree) pass property_overwrites
for relationship properties, not node properties.

Also adds a clarifying comment on the Bellman-Ford Arrow mutate endpoint:
the v2 endpoint uses writeNegativeCycles for both mutate and write modes,
unlike the Cypher procedure which uses mutateNegativeCycles for mutate.
