### PR TITLE
Fix stray self arg in exception constructors

### DIFF
--- a/src/graphdatascience/arrow_client/arrow_endpoint_version.py
+++ b/src/graphdatascience/arrow_client/arrow_endpoint_version.py
@@ -30,6 +30,5 @@ class ArrowEndpointVersion(Enum):
 class UnsupportedArrowEndpointVersion(Exception):
     def __init__(self, compatible_versions: set[ArrowEndpointVersion], supported_server_versions: set[str]) -> None:
         super().__init__(
-            self,
             f"The GDS version is not supported by this client version, please update the `graphdatascience` package. Arrow versions supported by this client are: {compatible_versions}, but GDS supports: {supported_server_versions}",
         )

--- a/src/graphdatascience/error/standalone_session_error.py
+++ b/src/graphdatascience/error/standalone_session_error.py
@@ -1,3 +1,3 @@
 class NotAvailableInStandaloneSessions(Exception):
     def __init__(self, subject: str) -> None:
-        super().__init__(self, f"{subject} is not available in standalone sessions")
+        super().__init__(f"{subject} is not available in standalone sessions")

--- a/tests/unit/test_arrow_endpoint_version.py
+++ b/tests/unit/test_arrow_endpoint_version.py
@@ -26,5 +26,5 @@ def test_check_version_compatibility() -> None:
 
     with pytest.raises(UnsupportedArrowEndpointVersion) as e:
         ArrowEndpointVersion.check_version_compatibility({ArrowEndpointVersion.V1}, arrow_client_mock)
-    assert "Unsupported" in str(e.value)
+    assert "please update the `graphdatascience` package" in str(e.value)
     assert "v1" in str(e.value)

--- a/tests/unit/test_exception_messages.py
+++ b/tests/unit/test_exception_messages.py
@@ -1,0 +1,24 @@
+import pytest
+
+from graphdatascience.arrow_client.arrow_endpoint_version import (
+    ArrowEndpointVersion,
+    UnsupportedArrowEndpointVersion,
+)
+from graphdatascience.error.standalone_session_error import NotAvailableInStandaloneSessions
+
+
+def test_not_available_in_standalone_sessions_message() -> None:
+    with pytest.raises(NotAvailableInStandaloneSessions) as e:
+        raise NotAvailableInStandaloneSessions("Running Cypher queries")
+
+    assert str(e.value) == "Running Cypher queries is not available in standalone sessions"
+
+
+def test_unsupported_arrow_endpoint_version_message() -> None:
+    with pytest.raises(UnsupportedArrowEndpointVersion) as e:
+        raise UnsupportedArrowEndpointVersion({ArrowEndpointVersion.V2}, {"v1"})
+
+    msg = str(e.value)
+    assert "please update the `graphdatascience` package" in msg
+    assert "v2" in msg
+    assert "v1" in msg


### PR DESCRIPTION
NotAvailableInStandaloneSessions and UnsupportedArrowEndpointVersion
passed self as the first argument to super().__init__, causing str(e)
to render as a tuple containing the exception instance instead of just
the message.
