### PR TITLE
Close Arrow Flight client in GraphDataScience.close()

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,7 @@
 * `GdsSessions.delete` now returns `False` if no session was deleted when called with a `session_id`. It previously always returned `True`.
 * `AuraApiError` and `SessionStatusError` no longer include a repetition of the exception object in their message.
 * The Arrow endpoint version is now checked when the client is created. If it is unsupported, the client raises an error asking to update the `graphdatascience` package, instead of failing later with an unrelated error.
+* `GraphDataScience.close()` now closes the Arrow Flight client in addition to the query runner.
 
 ## Improvements
 

--- a/src/graphdatascience/graph_data_science.py
+++ b/src/graphdatascience/graph_data_science.py
@@ -876,6 +876,8 @@ class GraphDataScience:
 
         If the GraphDataScience object was instantiated with a Neo4j Driver, the driver will not be closed as we cannot assume sole ownership of it.
         """
+        if self._arrow_client is not None:
+            self._arrow_client.close()
         self._query_runner.close()
 
     def __enter__(self) -> GraphDataScience:


### PR DESCRIPTION
GraphDataScience.close() only closed the query runner, leaking the
gRPC channel held by the Arrow Flight client. The arrow client is now
closed before the query runner, matching AuraGraphDataScience.close().
