### PR TITLE
Fix inverse_indexed_relationship_types typo in Arrow construct endpoint

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -33,6 +33,7 @@
 * `AuraApiError` and `SessionStatusError` no longer include a repetition of the exception object in their message.
 * The Arrow endpoint version is now checked when the client is created. If it is unsupported, the client raises an error asking to update the `graphdatascience` package, instead of failing later with an unrelated error.
 
+
 ## Improvements
 
 * `GraphDataScience` no longer requires the `aura_ds` parameter to be set. If left unset, the client automatically derives whether the database is hosted in Aura.

--- a/src/graphdatascience/procedure_surface/arrow/catalog/catalog_arrow_endpoints.py
+++ b/src/graphdatascience/procedure_surface/arrow/catalog/catalog_arrow_endpoints.py
@@ -84,7 +84,7 @@ class CatalogArrowEndpoints(CatalogEndpoints):
         relationships: DataFrame | typing.List[DataFrame] | None = None,
         concurrency: int | None = None,
         undirected_relationship_types: typing.List[str] | None = None,
-        inverse_index_relationship_types: typing.List[str] | None = None,
+        inverse_indexed_relationship_types: typing.List[str] | None = None,
         batch_size: int = 100000,
         overwrite: bool = False,
     ) -> Graph:
@@ -103,7 +103,7 @@ class CatalogArrowEndpoints(CatalogEndpoints):
             graph_name,
             concurrency,
             undirected_relationship_types,
-            inverse_index_relationship_types,
+            inverse_indexed_relationship_types,
             batch_size,
             self._show_progress,
         )

--- a/tests/unit/procedure_surface/arrow/test_catalog_arrow_endpoints.py
+++ b/tests/unit/procedure_surface/arrow/test_catalog_arrow_endpoints.py
@@ -182,6 +182,18 @@ def _construct_endpoints(mocker: MockerFixture, job_id: str) -> CatalogArrowEndp
     return CatalogArrowEndpoints(arrow_client=arrow_client)
 
 
+def test_construct_forwards_inverse_indexed_relationship_types(mocker: MockerFixture) -> None:
+    endpoints = _construct_endpoints(mocker, "job-123")
+
+    with patch_gds_arrow_client("job-123"):
+        endpoints.construct(
+            graph_name="g",
+            nodes=_construct_nodes(),
+            relationships=[],
+            inverse_indexed_relationship_types=["REL"],
+        )
+
+
 def test_construct_overwrite_drops_existing_graph(mocker: MockerFixture) -> None:
     endpoints = _construct_endpoints(mocker, "job-123")
     drop_spy = mocker.patch.object(endpoints._graph_ops, "drop")


### PR DESCRIPTION
The Arrow catalog construct() method had a parameter named
 (missing the 'd' in 'indexed'),
inconsistent with the Cypher endpoint and all downstream constructors
which use . The value was forwarded
positionally so it worked at runtime, but passing the correct keyword
name would raise a TypeError.
