### PR TITLE
Always auto-close cloned query runner in cloneWithoutRouting

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -33,6 +33,7 @@
 * `AuraApiError` and `SessionStatusError` no longer include a repetition of the exception object in their message.
 * The Arrow endpoint version is now checked when the client is created. If it is unsupported, the client raises an error asking to update the `graphdatascience` package, instead of failing later with an unrelated error.
 
+
 ## Improvements
 
 * `GraphDataScience` no longer requires the `aura_ds` parameter to be set. If left unset, the client automatically derives whether the database is hosted in Aura.

--- a/src/graphdatascience/query_runner/neo4j_query_runner.py
+++ b/src/graphdatascience/query_runner/neo4j_query_runner.py
@@ -389,7 +389,7 @@ class Neo4jQueryRunner(QueryRunner):
             auth=self._auth,
             config=self._config,
             database=self._database,
-            auto_close=self._auto_close,
+            auto_close=True,
             bookmarks=self._bookmarks,
             show_progress=self._show_progress,
             instance_description=self._instance_description,

--- a/tests/unit/query_runner/test_clone_without_routing.py
+++ b/tests/unit/query_runner/test_clone_without_routing.py
@@ -1,0 +1,27 @@
+from unittest.mock import MagicMock, patch
+
+from neo4j import GraphDatabase
+
+from graphdatascience.query_runner.neo4j_query_runner import Neo4jQueryRunner
+
+
+def test_clone_without_routing_always_auto_closes() -> None:
+    auth = ("neo4j", "password")
+    parent_driver = GraphDatabase.driver("bolt://localhost:7687", auth=auth)
+    try:
+        parent = Neo4jQueryRunner(
+            driver=parent_driver,
+            protocol="bolt",
+            auth=auth,
+            auto_close=False,
+        )
+
+        mock_clone_driver = MagicMock()
+        with patch.object(GraphDatabase, "driver", return_value=mock_clone_driver):
+            clone = parent.cloneWithoutRouting("localhost", 7687)
+
+        assert clone._auto_close is True  # type: ignore[attr-defined]
+        clone.close()
+        mock_clone_driver.close.assert_called_once()
+    finally:
+        parent_driver.close()


### PR DESCRIPTION
cloneWithoutRouting creates a brand-new Neo4j driver but inherited
auto_close from the parent runner. When a user passed their own driver
to GraphDataScience (auto_close=False), the cloned driver was never
closed, leaking connections. The clone now always sets auto_close=True
since it owns its driver.
