### PR TITLE
Add per-call timeout and wait_for_available to Arrow Flight client

### DIFF
--- a/src/graphdatascience/arrow_client/arrow_endpoint_version.py
+++ b/src/graphdatascience/arrow_client/arrow_endpoint_version.py
@@ -19,7 +19,9 @@ class ArrowEndpointVersion(Enum):
     def check_version_compatibility(
         compatible_versions: set[ArrowEndpointVersion], arrow_client: AuthenticatedArrowClient
     ) -> None:
-        supported_server_versions = {action.type.split("/")[0].lower() for action in arrow_client.list_actions()}
+        supported_server_versions = {
+            action.type.split("/")[0].lower() for action in arrow_client.list_actions_with_retry()
+        }
         for version in compatible_versions:
             if version.version() in supported_server_versions:
                 return

--- a/src/graphdatascience/arrow_client/authenticated_flight_client.py
+++ b/src/graphdatascience/arrow_client/authenticated_flight_client.py
@@ -13,6 +13,7 @@ from pyarrow import __version__ as arrow_version
 from pyarrow.flight import (
     Action,
     ActionType,
+    FlightCallOptions,
     FlightInternalError,
     FlightStreamReader,
     FlightTimedOutError,
@@ -58,7 +59,9 @@ class AuthenticatedArrowClient:
         encrypted
             A flag that indicates whether the connection should be encrypted (default is False)
         arrow_client_options
-            Additional options to be passed to the Arrow Flight client.
+            Additional options for the Arrow Flight client. The key ``call_timeout`` sets the
+            per-call RPC timeout in seconds (default 30s); all other keys are forwarded to
+            ``pyarrow.flight.FlightClient``.
         user_agent
             The user agent string to use for the connection. (default is `neo4j-graphdatascience-v[VERSION] pyarrow-v[PYARROW_VERSION]`)
         retry_config
@@ -87,17 +90,23 @@ class AuthenticatedArrowClient:
                 wait_config=ExponentialWaitConfig(multiplier=1, min=1, max=10),
             )
 
+        # Extract our own call_timeout before forwarding the rest to FlightClient
+        options_copy = dict(arrow_client_options) if arrow_client_options else {}
+        call_timeout = options_copy.pop("call_timeout", 30.0)
+
         self._host = host
         self._port = int(port)
         self._auth = auth
         self._encrypted = encrypted
-        self._arrow_client_options = arrow_client_options
+        self._arrow_client_options = options_copy or None
         self._user_agent = user_agent
         self._logger = logging.getLogger("gds_arrow_client")
         self._retry_config = retry_config
         self._health_check = health_check
         if auth:
             self._auth_middleware = AuthMiddleware(auth)
+        self._call_timeout = call_timeout
+        self._call_options = self._build_call_options()
         self.advertised_listen_address = advertised_listen_address
         self._flight_client: flight.FlightClient = self._instantiate_flight_client()
 
@@ -143,7 +152,7 @@ class AuthenticatedArrowClient:
                 client = self._flight_client
                 if self._auth:
                     auth_pair = self._auth.auth_pair()
-                    client.authenticate_basic_token(auth_pair[0], auth_pair[1])
+                    client.authenticate_basic_token(auth_pair[0], auth_pair[1], self._call_options)
             except (FlightTimedOutError, FlightUnavailableError, FlightInternalError):
                 self._reconnect()
                 raise
@@ -157,18 +166,22 @@ class AuthenticatedArrowClient:
     def get_stream(self, ticket: Ticket) -> FlightStreamReader:
         return self._flight_client.do_get(ticket)
 
-    def do_action(self, endpoint: str, payload: bytes | dict[str, Any]) -> Iterator[Result]:
+    def do_action(
+        self, endpoint: str, payload: bytes | dict[str, Any], options: FlightCallOptions | None = None
+    ) -> Iterator[Result]:
         payload_bytes = payload if isinstance(payload, bytes) else json.dumps(payload).encode("utf-8")
 
-        return self._flight_client.do_action(Action(endpoint, payload_bytes))  # type: ignore
+        return self._flight_client.do_action(Action(endpoint, payload_bytes), options or self._call_options)  # type: ignore
 
-    def do_action_with_retry(self, endpoint: str, payload: bytes | dict[str, Any]) -> list[Result]:
+    def do_action_with_retry(
+        self, endpoint: str, payload: bytes | dict[str, Any], options: FlightCallOptions | None = None
+    ) -> list[Result]:
         @self._retry_config.decorator(operation_name="Send action", logger=self._logger)
         def run_with_retry() -> list[Result]:
             try:
                 # the Flight response error code is only checked on iterator consumption
                 # we eagerly collect iterator here to trigger retry in case of an error
-                return list(self.do_action(endpoint, payload))
+                return list(self.do_action(endpoint, payload, options))
             except (FlightTimedOutError, FlightUnavailableError, FlightInternalError):
                 self._reconnect()
                 raise
@@ -176,7 +189,22 @@ class AuthenticatedArrowClient:
         return self._diagnose_connection_failure(run_with_retry)
 
     def list_actions(self) -> set[ActionType]:
-        return self._flight_client.list_actions()  # type: ignore
+        return self._flight_client.list_actions(self._call_options)  # type: ignore
+
+    def list_actions_with_retry(self) -> set[ActionType]:
+        @self._retry_config.decorator(operation_name="List actions", logger=self._logger)
+        def run_with_retry() -> set[ActionType]:
+            try:
+                return self.list_actions()
+            except (FlightTimedOutError, FlightUnavailableError, FlightInternalError):
+                self._reconnect()
+                raise
+
+        return self._diagnose_connection_failure(run_with_retry)
+
+    def wait_for_available(self, timeout: int = 30) -> None:
+        """Block until the Arrow Flight server can be contacted or the timeout fires."""
+        self._flight_client.wait_for_available(timeout)
 
     def do_put_with_retry(
         self, descriptor: flight.FlightDescriptor, schema: Schema
@@ -218,6 +246,9 @@ class AuthenticatedArrowClient:
         if self._flight_client:
             self._flight_client.close()
 
+    def _build_call_options(self) -> FlightCallOptions | None:
+        return FlightCallOptions(timeout=self._call_timeout) if self._call_timeout is not None else None
+
     def _instantiate_flight_client(self) -> flight.FlightClient:
         location = (
             flight.Location.for_grpc_tls(self._host, self._port)
@@ -248,11 +279,16 @@ class AuthenticatedArrowClient:
         # Remove the FlightClient as it isn't serializable
         if "_flight_client" in state:
             del state["_flight_client"]
+        # FlightCallOptions is also not serializable
+        if "_call_options" in state:
+            del state["_call_options"]
         return state
 
     def __setstate__(self, state: dict[str, Any]) -> None:
         self.__dict__.update(state)
         self.__dict__.setdefault("_health_check", None)
+        self.__dict__.setdefault("_call_timeout", 30.0)
+        self.__dict__.setdefault("_call_options", self._build_call_options())
         self._flight_client = self._instantiate_flight_client()
 
     def _reconnect(self) -> None:

--- a/src/graphdatascience/arrow_client/authenticated_flight_client.py
+++ b/src/graphdatascience/arrow_client/authenticated_flight_client.py
@@ -90,7 +90,6 @@ class AuthenticatedArrowClient:
                 wait_config=ExponentialWaitConfig(multiplier=1, min=1, max=10),
             )
 
-        # Extract our own call_timeout before forwarding the rest to FlightClient
         options_copy = dict(arrow_client_options) if arrow_client_options else {}
         call_timeout = options_copy.pop("call_timeout", 30.0)
 
@@ -166,22 +165,18 @@ class AuthenticatedArrowClient:
     def get_stream(self, ticket: Ticket) -> FlightStreamReader:
         return self._flight_client.do_get(ticket)
 
-    def do_action(
-        self, endpoint: str, payload: bytes | dict[str, Any], options: FlightCallOptions | None = None
-    ) -> Iterator[Result]:
+    def do_action(self, endpoint: str, payload: bytes | dict[str, Any]) -> Iterator[Result]:
         payload_bytes = payload if isinstance(payload, bytes) else json.dumps(payload).encode("utf-8")
 
-        return self._flight_client.do_action(Action(endpoint, payload_bytes), options or self._call_options)  # type: ignore
+        return self._flight_client.do_action(Action(endpoint, payload_bytes), self._call_options)  # type: ignore
 
-    def do_action_with_retry(
-        self, endpoint: str, payload: bytes | dict[str, Any], options: FlightCallOptions | None = None
-    ) -> list[Result]:
+    def do_action_with_retry(self, endpoint: str, payload: bytes | dict[str, Any]) -> list[Result]:
         @self._retry_config.decorator(operation_name="Send action", logger=self._logger)
         def run_with_retry() -> list[Result]:
             try:
                 # the Flight response error code is only checked on iterator consumption
                 # we eagerly collect iterator here to trigger retry in case of an error
-                return list(self.do_action(endpoint, payload, options))
+                return list(self.do_action(endpoint, payload))
             except (FlightTimedOutError, FlightUnavailableError, FlightInternalError):
                 self._reconnect()
                 raise
@@ -201,10 +196,6 @@ class AuthenticatedArrowClient:
                 raise
 
         return self._diagnose_connection_failure(run_with_retry)
-
-    def wait_for_available(self, timeout: int = 30) -> None:
-        """Block until the Arrow Flight server can be contacted or the timeout fires."""
-        self._flight_client.wait_for_available(timeout)
 
     def do_put_with_retry(
         self, descriptor: flight.FlightDescriptor, schema: Schema

--- a/src/graphdatascience/session/gds_sessions.py
+++ b/src/graphdatascience/session/gds_sessions.py
@@ -209,7 +209,7 @@ class GdsSessions:
             cloud_location (CloudLocation | None): The cloud location. Required if the GDS session is for a self-managed database.
             timeout (int | None): Optional timeout (in seconds) when waiting for session to become ready. If unset the method will wait forever. If set and session does not become ready an exception will be raised. It is user responsibility to ensure resource gets cleaned up in this situation.
             neo4j_driver_config (dict[str, Any] | None): Optional configuration for the Neo4j driver to the Neo4j DBMS. Only relevant if `db_connection` is specified..
-            arrow_client_options (dict[str, Any] | None): Optional configuration for the Arrow Flight client.
+            arrow_client_options (dict[str, Any] | None): Optional configuration for the Arrow Flight client. The key ``call_timeout`` sets the per-call RPC timeout in seconds (default 30s).
             show_progress (bool): Whether the returned client should print its own job-progress bars (projection, algorithm execution, ...). Defaults to True.
         Returns
         -------

--- a/tests/unit/test_arrow_endpoint_version.py
+++ b/tests/unit/test_arrow_endpoint_version.py
@@ -16,7 +16,7 @@ def test_prefix() -> None:
 
 def test_check_version_compatibility() -> None:
     arrow_client_mock = mock.Mock(AuthenticatedArrowClient)
-    arrow_client_mock.list_actions.return_value = [
+    arrow_client_mock.list_actions_with_retry.return_value = [
         ActionType("v2/foo", ""),
         ActionType("v2/bar", ""),
         ActionType("v3/baz", ""),


### PR DESCRIPTION
Fixes hangs in GDS release checks where the Arrow gRPC server accepts a
TCP connection but never responds, causing xdist workers to block
indefinitely on socket reads (20min pytest timeout → worker crash).

ref GDSA-1548