### PR TITLE
Fix similarity notebook for 2.0 API and CI compatibility

### DIFF
--- a/examples/similarity_algorithms.ipynb
+++ b/examples/similarity_algorithms.ipynb
@@ -3,7 +3,9 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "wAV1WpeCQRmA"
+    "tags": [
+     "aura"
+    ]
    },
    "source": [
     "# Similarity Algorithms in Neo4j"
@@ -11,9 +13,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "5it3sXoKQRmC"
-   },
+   "metadata": {},
    "source": [
     "<a target=\"_blank\" href=\"https://colab.research.google.com/github/neo4j/graph-data-science-client/blob/main/examples/similarity_algorithms.ipynb\">\n",
     "  <img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/>\n",
@@ -22,11 +22,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "DwOIB8wwQRmD"
-   },
+   "metadata": {},
    "source": [
-    "This Jupyter notebook is inspired by examples in the [Neo4j Graph Data Science Client Github repository](https://github.com/neo4j/graph-data-science-client/tree/main/examples).\n",
+    "This Jupyter notebook is hosted [here](https://github.com/neo4j/graph-data-science-client/blob/main/examples/similarity_algorithms.ipynb) in the Neo4j Graph Data Science Client Github repository.\n",
     "\n",
     "The notebook demonstrates the usage of the `graphdatascience` library for performing similarity analysis on the **SNAP MOOC dataset**, which can be downloaded [here](https://snap.stanford.edu/data/act-mooc.html).\n",
     "\n",
@@ -35,9 +33,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "myz4JfCOQUv5"
-   },
+   "metadata": {},
    "source": [
     "## Dataset Overview: `act-mooc`\n",
     "\n",
@@ -60,26 +56,19 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "91bf2b60"
-   },
+   "metadata": {},
    "source": [
-    "# Graph Similarity Algorithms in Neo4j GDS\n",
+    "## Learning Objectives\n",
     "\n",
-    "This notebook demonstrates how to calculate and compare different graph similarity metrics using the SNAP `act-mooc` dataset and Neo4j Graph Data Science (GDS).\n",
-    "\n",
-    "### Learning Objectives:\n",
     "1.  **Data Ingestion**: Load large-scale interaction data into Neo4j Aura.\n",
     "2.  **Graph Projections**: Create in-memory graphs for analysis.\n",
-    "3.  **Similarity Algorithms**: Execute Node Similarity in various modes (Stream, Stats, Mutate).\n",
-    "4.  **Metric Comparison**: Understand the differences between Jaccard, Overlap, Cosine similarities."
+    "3.  **Similarity Algorithms**: Execute Node Similarity in various modes (Stream, Mutate, Write).\n",
+    "4.  **Metric Comparison**: Understand the differences between Jaccard, Overlap, and Cosine similarities.\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "74f2da05"
-   },
+   "metadata": {},
    "source": [
     "## Setup for SNAP `act-mooc` Dataset"
    ]
@@ -90,7 +79,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os, requests\n",
+    "import os\n",
+    "import tarfile\n",
+    "\n",
+    "import requests\n",
     "\n",
     "url = \"https://snap.stanford.edu/data/act-mooc.tar.gz\"\n",
     "dest = \"act-mooc.tar.gz\"\n",
@@ -99,28 +91,26 @@
     "with open(dest, \"wb\") as f:\n",
     "    f.write(requests.get(url).content)\n",
     "\n",
-    "!mkdir -p act-mooc_data && tar -xzf {dest} -C act-mooc_data\n",
+    "os.makedirs(\"act-mooc_data\", exist_ok=True)\n",
+    "with tarfile.open(dest, \"r:gz\") as tar:\n",
+    "    tar.extractall(\"act-mooc_data\")\n",
     "print(\"Done. Contents:\")\n",
-    "!ls -R act-mooc_data"
+    "for root, dirs, files in os.walk(\"act-mooc_data\"):\n",
+    "    for f in files:\n",
+    "        print(os.path.join(root, f))"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "id": "01dc59b2"
+    "tags": [
+     "verify-version"
+    ]
    },
+   "outputs": [],
    "source": [
-    "### Data Extraction Complete\n",
-    "The MOOC interaction data (actions, features, and labels) has been successfully downloaded and extracted. We are now ready to begin the Neo4j ingestion process."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "mGdfH2dkomEF"
-   },
-   "source": [
-    "# Neo4j setup"
+    "%pip install \"graphdatascience>2.0a5\" python-dotenv"
    ]
   },
   {
@@ -129,94 +119,56 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pip install neo4j"
+    "import os\n",
+    "\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "# This allows to load required secrets from `.env` file in local directory\n",
+    "# This can include Aura API Credentials and Database Credentials.\n",
+    "# If file does not exist this is a noop.\n",
+    "load_dotenv(\".env\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "b2f0aebf"
-   },
+   "metadata": {},
+   "source": [
+    "## Aura API credentials\n",
+    "\n",
+    "The entry point for managing GDS Sessions is the `GdsSessions` object, which requires creating [Aura API credentials](https://neo4j.com/docs/aura/api/authentication).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from graphdatascience.session import AuraAPICredentials, GdsSessions\n",
+    "\n",
+    "api_credentials = AuraAPICredentials(\n",
+    "    client_id=os.environ[\"CLIENT_ID\"],\n",
+    "    client_secret=os.environ[\"CLIENT_SECRET\"],\n",
+    "    tenant_id=os.environ[\"PROJECT_ID\"],\n",
+    ")\n",
+    "\n",
+    "sessions = GdsSessions(api_credentials=api_credentials)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Section 1: Data Preparation\n",
     "\n",
-    "In this section, we download the dataset and define the ingestion logic to map TSV files to a Graph Schema consisting of `MoocUser`, `MoocAction`, and `MoocActivity` nodes."
+    "In this section, we download the dataset and define the ingestion logic to map TSV files to a graph schema consisting of `MoocUser`, `MoocAction`, and `MoocActivity` nodes.\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "bew0R8z5MzPh"
-   },
-   "source": [
-    "Get the Client ID and Client Secret from here: https://console.neo4j.io/account/api-keys\n",
-    "\n",
-    "Refrence article: https://neo4j.com/docs/aura/api/authentication/"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
-    "from neo4j import GraphDatabase\n",
-    "\n",
-    "# URI examples: \"neo4j://localhost\", \"neo4j+s://xxx.databases.neo4j.io\"\n",
-    "URI = \"<URI>\"\n",
-    "AUTH = (\"<USERNAME>\", \"<PASSWORD>\")\n",
-    "USERNAME = \"<USERNAME>\"\n",
-    "PASSWORD = \"<PASSWORD>\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "CLIENT_ID = \"<CLIENT_ID>\"\n",
-    "CLIENT_SECRET = \"<CLIENT_SECRET>\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "u5z-5nWVou7B"
-   },
-   "source": [
-    "### 1.1 Graph Data Science Setup"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pip install graphdatascience"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from graphdatascience.session import GdsSessions, AuraAPICredentials\n",
-    "\n",
-    "PROJECT_ID = None\n",
-    "# Create a new GdsSessions object\n",
-    "sessions = GdsSessions(api_credentials=AuraAPICredentials(CLIENT_ID, CLIENT_SECRET, PROJECT_ID))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "OD0jVbFzo5QA"
-   },
-   "source": [
-    "### 1.2 Connecting to Session"
+    "### 1.1 Connecting to Session"
    ]
   },
   {
@@ -228,37 +180,40 @@
     "from graphdatascience.session import DbmsConnectionInfo, SessionMemory\n",
     "\n",
     "db_connection = DbmsConnectionInfo(\n",
-    "     uri=URI,\n",
-    "     username=USERNAME,\n",
-    "     password=PASSWORD\n",
+    "    uri=os.environ[\"NEO4J_URI\"],\n",
+    "    username=os.environ[\"NEO4J_USERNAME\"],\n",
+    "    password=os.environ[\"NEO4J_PASSWORD\"],\n",
     ")\n",
     "\n",
     "gds = sessions.get_or_create(\n",
     "    session_name=\"Similarity\",\n",
     "    memory=SessionMemory.m_2GB,\n",
     "    db_connection=db_connection,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "e024b733"
-   },
-   "source": [
-    "### 1.3 Populate Neo4j Instance and Project Graph\n",
-    "This section creates a sample social network and projects it into the GDS session for analysis."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "af2ZfBI4V-Bm"
-   },
-   "source": [
-    "We will use [CONSTRAINTS](https://neo4j.com/docs/cypher-manual/current/schema/constraints/create-constraints/) here,\n",
+    ")\n",
     "\n",
-    "In Cypher, constraints are schema-level rules applied to node labels or relationship types to enforce data integrity, maintain consistency, and safeguard the graph."
+    "gds.verify_connectivity()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 1.2 Populate Neo4j Instance and Project Graph\n",
+    "\n",
+    "This section creates the graph schema and projects it into the GDS session for analysis.\n",
+    "\n",
+    "We will use [CONSTRAINTS](https://neo4j.com/docs/cypher-manual/current/schema/constraints/create-constraints/) here.\n",
+    "\n",
+    "In Cypher, constraints are schema-level rules applied to node labels or relationship types to enforce data integrity, maintain consistency, and safeguard the graph.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Step 1: Tutorial Setup & Constraints\n",
+    "\n",
+    "We define the dataset paths and schema constraints to ensure data integrity during ingestion.\n"
    ]
   },
   {
@@ -267,16 +222,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Step 1: Tutorial Setup & Constants\n",
-    "from __future__ import annotations\n",
-    "import csv, math, os, sys\n",
+    "import csv\n",
     "from decimal import Decimal\n",
-    "from pathlib import Path\n",
-    "from typing import Iterable, Iterator\n",
     "from itertools import islice\n",
+    "from pathlib import Path\n",
     "\n",
     "# dataset paths\n",
-    "DATA_DIR = Path(\"/content/act-mooc_data/act-mooc\")\n",
+    "DATA_DIR = Path(\"act-mooc_data/act-mooc\")\n",
     "DATASET_ID = \"act-mooc\"\n",
     "\n",
     "# Schema constraints to ensure data integrity\n",
@@ -284,23 +236,19 @@
     "    \"CREATE CONSTRAINT mooc_user_identity IF NOT EXISTS FOR (u:MoocUser) REQUIRE (u.datasetId, u.userId) IS UNIQUE\",\n",
     "    \"CREATE CONSTRAINT mooc_activity_identity IF NOT EXISTS FOR (t:MoocActivity) REQUIRE (t.datasetId, t.targetId) IS UNIQUE\",\n",
     "    \"CREATE CONSTRAINT mooc_action_identity IF NOT EXISTS FOR (a:MoocAction) REQUIRE (a.datasetId, a.actionId) IS UNIQUE\",\n",
-    "    \"CREATE RANGE INDEX mooc_action_time IF NOT EXISTS FOR (a:MoocAction) ON (a.datasetId, a.timestampSeconds)\"\n",
+    "    \"CREATE RANGE INDEX mooc_action_time IF NOT EXISTS FOR (a:MoocAction) ON (a.datasetId, a.timestampSeconds)\",\n",
     "]"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "b9f25b6d"
-   },
+   "metadata": {},
    "source": [
     "### Step 2: The Ingestion Engine\n",
     "\n",
     "In this step, we define the core functions responsible for reading the TSV files and batching the data. Using a generator (`yield`) and a chunking function helps us stay within memory limits and handle large datasets efficiently.\n",
     "\n",
-    "Note: We are limiting this to 150000 as free tier supports 2gb Memory, you can change this in session creation\n",
-    "\n",
-    "*Modify 'memory=SessionMemory.m_2GB' per your needs*\n"
+    "Note: We are limiting this to 150000 as the session supports 2GB memory. You can change this by increasing the session memory allocation.\n"
    ]
   },
   {
@@ -309,48 +257,47 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Step 2: Define the Ingestion Engine\n",
     "def get_action_rows(limit=150000):\n",
     "    \"\"\"Parses the 3 TSV files into a unified dictionary format.\"\"\"\n",
-    "    a_path, f_path, l_path = DATA_DIR/\"mooc_actions.tsv\", DATA_DIR/\"mooc_action_features.tsv\", DATA_DIR/\"mooc_action_labels.tsv\"\n",
+    "    a_path = DATA_DIR / \"mooc_actions.tsv\"\n",
+    "    f_path = DATA_DIR / \"mooc_action_features.tsv\"\n",
+    "    l_path = DATA_DIR / \"mooc_action_labels.tsv\"\n",
     "    with open(a_path) as ah, open(f_path) as fh, open(l_path) as lh:\n",
-    "        zipped = zip(csv.DictReader(ah, delimiter='\\t'), csv.DictReader(fh, delimiter='\\t'), csv.DictReader(lh, delimiter='\\t'))\n",
+    "        zipped = zip(\n",
+    "            csv.DictReader(ah, delimiter=\"\\t\"),\n",
+    "            csv.DictReader(fh, delimiter=\"\\t\"),\n",
+    "            csv.DictReader(lh, delimiter=\"\\t\"),\n",
+    "        )\n",
     "        for i, (a_row, f_row, l_row) in enumerate(islice(zipped, limit)):\n",
     "            yield {\n",
-    "                \"actionId\": i, \"userId\": int(a_row[\"USERID\"]), \"targetId\": int(a_row[\"TARGETID\"]),\n",
+    "                \"actionId\": i,\n",
+    "                \"userId\": int(a_row[\"USERID\"]),\n",
+    "                \"targetId\": int(a_row[\"TARGETID\"]),\n",
     "                \"timestampSeconds\": int(Decimal(a_row[\"TIMESTAMP\"])),\n",
     "                \"featureVector\": [float(f_row[f\"FEATURE{j}\"]) for j in range(4)],\n",
     "                \"dropoutAfterAction\": bool(int(l_row[\"LABEL\"])),\n",
     "                \"sourceLabelActionId\": int(l_row[\"ACTIONID\"]),\n",
     "            }\n",
     "\n",
+    "\n",
     "def chunked(rows, size=5000):\n",
     "    batch = []\n",
     "    for r in rows:\n",
     "        batch.append(r)\n",
-    "        if len(batch) == size: yield batch; batch = []\n",
-    "    if batch: yield batch"
+    "        if len(batch) == size:\n",
+    "            yield batch\n",
+    "            batch = []\n",
+    "    if batch:\n",
+    "        yield batch"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "9ba8125b"
-   },
+   "metadata": {},
    "source": [
     "### Step 3: Executing the Ingestion\n",
     "\n",
-    "Finally, we apply the database constraints and execute the batch import. We use `my_session.run_cypher` to send chunks of data to Neo4j. This approach ensures high throughput while preventing the transaction log from growing too large."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "dd5cd6c5"
-   },
-   "source": [
-    "#### Import act-mooc Dataset\n",
-    "This cell will execute the import process to write the MOOC data to your Neo4j database. We pass `['import', '--write']` to the main function to trigger the writing logic."
+    "Finally, we apply the database constraints and execute the batch import. We use `gds.run_cypher` to send chunks of data to Neo4j. This approach ensures high throughput while preventing the transaction log from growing too large.\n"
    ]
   },
   {
@@ -371,18 +318,26 @@
     "MERGE (a)-[:ON_ACTIVITY]->(t)\n",
     "\"\"\"\n",
     "\n",
-    "# Step 3: Run the Ingestion\n",
     "print(\"Applying schema constraints...\")\n",
-    "for cmd in CONSTRAINTS: gds.run_cypher(cmd)\n",
+    "for cmd in CONSTRAINTS:\n",
+    "    gds.run_cypher(cmd)\n",
     "\n",
     "print(\"Starting batch import...\")\n",
     "total = 0\n",
     "for batch in chunked(get_action_rows()):\n",
-    "    res = gds.run_cypher(IMPORT_CYPHER, params={\"datasetId\": DATASET_ID, \"rows\": batch})\n",
+    "    gds.run_cypher(IMPORT_CYPHER, params={\"datasetId\": DATASET_ID, \"rows\": batch})\n",
     "    total += len(batch)\n",
-    "    if total % 25000 == 0: print(f\"Imported {total} actions...\")\n",
+    "    if total % 25000 == 0:\n",
+    "        print(f\"Imported {total} actions...\")\n",
     "\n",
     "print(f\"\\nSuccess! Total actions imported: {total}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Database Stats: Labels and Relationships\n"
    ]
   },
   {
@@ -393,7 +348,7 @@
    "source": [
     "import pandas as pd\n",
     "\n",
-    "# Query to count nodes by label for the 'act-mooc' dataset\n",
+    "# Query to count nodes by label for the act-mooc dataset\n",
     "verify_query = \"\"\"\n",
     "MATCH (n)\n",
     "WHERE n.datasetId = 'act-mooc'\n",
@@ -401,22 +356,8 @@
     "ORDER BY Count DESC\n",
     "\"\"\"\n",
     "\n",
-    "# Using the existing GDS session to run the query\n",
     "counts_df = gds.run_cypher(verify_query)\n",
-    "if counts_df.empty:\n",
-    "    print(\"No nodes found for dataset 'act-mooc'.\")\n",
-    "else:\n",
-    "    display(counts_df)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "c18ecbfa"
-   },
-   "source": [
-    "#### Run Cypher Query on GDS Session\n",
-    "Use the cell below to execute Cypher queries. Replace the `query` string with your desired Cypher code."
+    "display(counts_df)"
    ]
   },
   {
@@ -425,94 +366,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Define your Cypher query here\n",
-    "query = \"\"\"\n",
-    "MATCH (n)\n",
-    "RETURN labels(n) AS Label, count(*) AS Count\n",
-    "LIMIT 10\n",
-    "\"\"\"\n",
-    "\n",
-    "# Execute the query using the active GDS session\n",
-    "result = gds.run_cypher(query)\n",
-    "\n",
-    "# Display the results\n",
-    "display(result)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "99d0d0a3"
-   },
-   "source": [
-    "#### Database Stats: Labels and Relationships"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Check Node Label counts\n",
-    "node_counts = gds.run_cypher(\"\"\"\n",
-    "    MATCH (n)\n",
-    "    RETURN labels(n) AS Labels, count(*) AS Count\n",
-    "\"\"\")\n",
-    "\n",
-    "# Check Relationship Type counts\n",
     "rel_counts = gds.run_cypher(\"\"\"\n",
     "    MATCH ()-[r]->()\n",
     "    RETURN type(r) AS Type, count(*) AS Count\n",
-    "\"\"\")\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"--- Node Label Counts ---\")\n",
-    "if node_counts.empty:\n",
-    "    print(\"No nodes found.\")\n",
-    "else:\n",
-    "    display(node_counts)\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"\\n--- Relationship Type Counts ---\")\n",
-    "if rel_counts.empty:\n",
-    "    print(\"No relationships found.\")\n",
-    "else:\n",
-    "    display(rel_counts)"
+    "\"\"\")\n",
+    "display(rel_counts)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "c4209502"
-   },
-   "source": [
-    "## Node Similarity Algorithm\n",
-    "We will now use the Graph Data Science Node Similarity algorithm. This algorithm compares sets of nodes (e.g., users) based on the nodes they are connected to (e.g., activities) using metrics like Jaccard Similarity."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "a2e7fd0b"
-   },
+   "metadata": {},
    "source": [
     "## Section 2: Structural Node Similarity\n",
     "\n",
-    "Node Similarity in GDS compares sets of neighbors. Here, we compare users based on the activities they have interacted with. We will explore how different metrics respond to the graph structure."
+    "Node Similarity in GDS compares sets of neighbors. Here, we compare users based on the activities they have interacted with. We will explore how different metrics respond to the graph structure.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.1 Project a Bipartite Graph for Node Similarity"
    ]
   },
   {
@@ -536,30 +410,18 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 2.1 Project a Bipartite Graph for Node Similarity\n"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "graph_name = 'user-activity-similarity'\n",
+    "graph_name = \"user-activity-similarity\"\n",
     "\n",
-    "# Drop graph if it already exists in the catalog\n",
-    "if gds.graph.exists(graph_name)['exists']:\n",
-    "    g_existing = gds.graph.get(graph_name)\n",
-    "    gds.graph.drop(g_existing)\n",
-    "\n",
-    "# Execute the AGA remote projection via gds.graph.project\n",
-    "g_sim, project_result = gds.graph.project(\n",
+    "g_sim, project_result = gds.graph.project.cypher(\n",
     "    graph_name,\n",
     "    REMOTE_PROJECT_CYPHER,\n",
-    "    query_parameters={\"datasetId\": \"act-mooc\"}\n",
+    "    query_parameters={\"datasetId\": \"act-mooc\"},\n",
+    "    overwrite=True,\n",
     ")\n",
     "\n",
     "print(f\"Graph '{graph_name}' projected successfully.\")\n",
@@ -579,39 +441,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pandas as pd\n",
     "import matplotlib.pyplot as plt\n",
-    "import seaborn as sns\n",
     "\n",
     "print(\"Running Node Similarity algorithm...\")\n",
-    "similarity_results = gds.nodeSimilarity.stream(\n",
+    "similarity_results = gds.node_similarity.stream(\n",
     "    g_sim,\n",
-    "    topK=5,\n",
-    "    similarityCutoff=0.1\n",
+    "    top_k=5,\n",
+    "    similarity_cutoff=0.1,\n",
     ")\n",
     "\n",
-    "if similarity_results.empty:\n",
-    "    print(\"No similarity pairs found with the current threshold (0.1).\")\n",
-    "else:\n",
-    "    similarity_results = similarity_results.rename(columns={\n",
-    "        \"node1\": \"user1_id\",\n",
-    "        \"node2\": \"user2_id\",\n",
-    "        \"similarity\": \"jaccard_score\"\n",
-    "    })\n",
+    "similarity_results = similarity_results.rename(\n",
+    "    columns={\"node1\": \"user1_id\", \"node2\": \"user2_id\", \"similarity\": \"jaccard_score\"}\n",
+    ")\n",
     "\n",
-    "    similarity_results['user1_id'] = similarity_results['user1_id'].astype(int)\n",
-    "    similarity_results['user2_id'] = similarity_results['user2_id'].astype(int)\n",
-    "\n"
+    "similarity_results[\"user1_id\"] = similarity_results[\"user1_id\"].astype(int)\n",
+    "similarity_results[\"user2_id\"] = similarity_results[\"user2_id\"].astype(int)\n",
+    "\n",
+    "display(similarity_results.head(10))"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "7a7e4d6a"
-   },
+   "metadata": {},
    "source": [
-    "### Advanced Node Similarity: Stats, Mutate, and Write Modes\n",
-    "Following the GDS documentation, we will now explore the other execution modes and result limiting techniques."
+    "### Visualizing Jaccard Similarity Distribution\n"
    ]
   },
   {
@@ -620,16 +473,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import matplotlib.pyplot as plt\n",
-    "import seaborn as sns\n",
-    "\n",
-    "# Visualize the distribution of Jaccard Similarity scores\n",
     "plt.figure(figsize=(10, 6))\n",
-    "sns.histplot(similarity_results['jaccard_score'], bins=30, kde=True, color='skyblue')\n",
-    "plt.title('Distribution of Jaccard Similarity Scores between Users')\n",
-    "plt.xlabel('Jaccard Similarity Score')\n",
-    "plt.ylabel('Frequency')\n",
-    "plt.grid(axis='y', linestyle='--', alpha=0.7)\n",
+    "plt.hist(similarity_results[\"jaccard_score\"], bins=30, color=\"skyblue\", edgecolor=\"black\")\n",
+    "plt.title(\"Distribution of Jaccard Similarity Scores between Users\")\n",
+    "plt.xlabel(\"Jaccard Similarity Score\")\n",
+    "plt.ylabel(\"Frequency\")\n",
+    "plt.grid(axis=\"y\", linestyle=\"--\", alpha=0.7)\n",
     "plt.show()"
    ]
   },
@@ -637,9 +486,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2.2 Mutate Mode: \n",
-    "Save similarity scores as relationships within the in-memory graph\n",
-    "Mutate mode adds relationships to the projected graph and returns summary execution statistics."
+    "### 2.2 Mutate Mode\n",
+    "\n",
+    "Save similarity scores as relationships within the in-memory graph.\n",
+    "Mutate mode adds relationships to the projected graph and returns summary execution statistics.\n"
    ]
   },
   {
@@ -648,12 +498,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "mutate_results = gds.nodeSimilarity.mutate(\n",
+    "mutate_results = gds.node_similarity.mutate(\n",
     "    g_sim,\n",
-    "    mutateRelationshipType='SIMILAR_TO',\n",
-    "    mutateProperty='score',\n",
-    "    similarityCutoff=0.5 # Only highly similar pairs\n",
+    "    mutate_relationship_type=\"SIMILAR_TO\",\n",
+    "    mutate_property=\"score\",\n",
+    "    similarity_cutoff=0.5,\n",
     ")\n",
     "\n",
     "print(\"Mutate Mode Results (Relationships added to in-memory graph):\")\n",
@@ -666,20 +515,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"Nodes compared:        {mutate_results['nodesCompared']}\")\n",
-    "print(f\"Relationships created: {mutate_results['relationshipsWritten']}\")\n",
-    "print(f\"Compute time (ms):     {mutate_results['computeMillis']}\")\n",
+    "print(f\"Nodes compared:        {mutate_results.nodes_compared}\")\n",
+    "print(f\"Relationships created: {mutate_results.relationships_written}\")\n",
+    "print(f\"Compute time (ms):     {mutate_results.compute_millis}\")\n",
     "print(\"\\nSimilarity distribution:\")\n",
-    "display(pd.Series(mutate_results['similarityDistribution']))"
+    "display(pd.Series(mutate_results.similarity_distribution))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### 2.3 Write Mode: \n",
-    "Persist the top similarity results back to the Neo4j Database\n",
-    "We write back the 'SIMILAR_TO' relationships and 'score' property mutated in Step 4."
+    "### 2.3 Write Mode\n",
+    "\n",
+    "Persist the top similarity results back to the Neo4j Database.\n",
+    "We write back the `SIMILAR_TO` relationships and `score` property mutated in the previous step.\n"
    ]
   },
   {
@@ -688,28 +538,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "write_results = gds.graph.relationships.write(\n",
+    "    g_sim,\n",
+    "    \"SIMILAR_TO\",\n",
+    "    [\"score\"],\n",
+    ")\n",
     "\n",
-    "\n",
-    "try:\n",
-    "    write_results = gds.graph.relationshipProperties.write(\n",
-    "        g_sim,\n",
-    "        'SIMILAR_TO',\n",
-    "        ['score']\n",
-    "    )\n",
-    "    print(\"Write Mode Results (Persisted mutated relationships back to Neo4j):\")\n",
-    "    display(write_results)\n",
-    "except Exception as e:\n",
-    "    print(f\"Write mode failed: {e}\")"
+    "print(\"Write Mode Results (Persisted mutated relationships back to Neo4j):\")\n",
+    "display(write_results)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "b6245efb"
-   },
+   "metadata": {},
    "source": [
     "### Implementing Multiple Similarity Metrics\n",
-    "We will now compare the results of **Jaccard**, **Overlap**, and **Cosine** similarity metrics."
+    "\n",
+    "We will now compare the results of **Jaccard**, **Overlap**, and **Cosine** similarity metrics.\n"
    ]
   },
   {
@@ -717,7 +562,8 @@
    "metadata": {},
    "source": [
     "### Jaccard Similarity (Intersection / Union)\n",
-    "Best suited for comparing unweighted neighbour sets"
+    "\n",
+    "Best suited for comparing unweighted neighbour sets.\n"
    ]
   },
   {
@@ -726,23 +572,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "# Drop graph if it already exists in the catalog\n",
-    "gds.graph.drop('user-activity-similarity', failIfMissing=False)\n",
-    "\n",
-    "# Project graph using AGA Remote Projection syntax\n",
-    "g_sim, project_result = gds.graph.project(\n",
-    "    'user-activity-similarity',\n",
+    "g_sim, project_result = gds.graph.project.cypher(\n",
+    "    \"user-activity-similarity\",\n",
     "    REMOTE_PROJECT_CYPHER,\n",
-    "    query_parameters={\"datasetId\": \"act-mooc\"}\n",
+    "    query_parameters={\"datasetId\": \"act-mooc\"},\n",
+    "    overwrite=True,\n",
     ")\n",
     "\n",
-    "# Stream Jaccard Similarity results\n",
-    "jaccard_df = gds.nodeSimilarity.stream(\n",
+    "jaccard_df = gds.node_similarity.stream(\n",
     "    g_sim,\n",
-    "    similarityMetric='JACCARD',\n",
-    "    topK=5,\n",
-    "    similarityCutoff=0.1\n",
+    "    similarity_metric=\"JACCARD\",\n",
+    "    top_k=5,\n",
+    "    similarity_cutoff=0.1,\n",
     ")\n",
     "\n",
     "print(\"Top Pairs using Jaccard Similarity (Default):\")\n",
@@ -754,7 +595,8 @@
    "metadata": {},
    "source": [
     "### Overlap Coefficient (Intersection / Min(|A|, |B|))\n",
-    "Best suited for detecting when one neighbour set is mostly contained in another"
+    "\n",
+    "Best suited for detecting when one neighbour set is mostly contained in another.\n"
    ]
   },
   {
@@ -763,22 +605,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Drop graph if it already exists\n",
-    "gds.graph.drop('user-activity-similarity', failIfMissing=False)\n",
-    "\n",
-    "# Project graph using AGA Remote Projection syntax\n",
-    "g_sim, project_result = gds.graph.project(\n",
-    "    'user-activity-similarity',\n",
+    "g_sim, project_result = gds.graph.project.cypher(\n",
+    "    \"user-activity-similarity\",\n",
     "    REMOTE_PROJECT_CYPHER,\n",
-    "    query_parameters={\"datasetId\": \"act-mooc\"}\n",
+    "    query_parameters={\"datasetId\": \"act-mooc\"},\n",
+    "    overwrite=True,\n",
     ")\n",
     "\n",
-    "# Stream Overlap Coefficient results\n",
-    "overlap_df = gds.nodeSimilarity.stream(\n",
+    "overlap_df = gds.node_similarity.stream(\n",
     "    g_sim,\n",
-    "    similarityMetric='OVERLAP',\n",
-    "    topK=5,\n",
-    "    similarityCutoff=0.1\n",
+    "    similarity_metric=\"OVERLAP\",\n",
+    "    top_k=5,\n",
+    "    similarity_cutoff=0.1,\n",
     ")\n",
     "\n",
     "print(\"Top Pairs using Overlap Coefficient:\")\n",
@@ -787,19 +625,13 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "96e748b9"
-   },
-   "source": [
-    "For **Cosine Similarity**, we need a relationship property to act as a weight. We will re-project the graph to count the number of actions between a User and an Activity as a weight."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "For **Cosine Similarity**, we need a relationship property to act as a weight. We will re-project the graph to count the number of actions between a User and an Activity as a weight.\n",
+    "\n",
     "### Cosine Similarity (Weighted Dot Product)\n",
-    "Best suited for weighted relationships"
+    "\n",
+    "Best suited for weighted relationships.\n"
    ]
   },
   {
@@ -808,10 +640,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Drop graph if it already exists\n",
-    "gds.graph.drop('weighted-sim', failIfMissing=False)\n",
-    "\n",
-    "# AGA Remote Projection for Weighted Graph\n",
     "weighted_project_query = \"\"\"\n",
     "MATCH (u:MoocUser {datasetId: $datasetId})-[:PERFORMED]->(a:MoocAction)-[:ON_ACTIVITY]->(t:MoocActivity {datasetId: $datasetId})\n",
     "WITH u, t, count(a) as interaction_count\n",
@@ -827,16 +655,19 @@
     ")\n",
     "\"\"\".strip()\n",
     "\n",
-    "# Execute remote weighted graph projection\n",
-    "g_weighted, _ = gds.graph.project('weighted-sim', weighted_project_query, query_parameters={\"datasetId\": \"act-mooc\"})\n",
+    "g_weighted, _ = gds.graph.project.cypher(\n",
+    "    \"weighted-sim\",\n",
+    "    weighted_project_query,\n",
+    "    query_parameters={\"datasetId\": \"act-mooc\"},\n",
+    "    overwrite=True,\n",
+    ")\n",
     "\n",
-    "# Stream Cosine Similarity using interaction_count weights\n",
-    "cosine_df = gds.nodeSimilarity.stream(\n",
+    "cosine_df = gds.node_similarity.stream(\n",
     "    g_weighted,\n",
-    "    similarityMetric='COSINE',\n",
-    "    relationshipWeightProperty='weight',\n",
-    "    topK=5,\n",
-    "    similarityCutoff=0.1\n",
+    "    similarity_metric=\"COSINE\",\n",
+    "    relationship_weight_property=\"weight\",\n",
+    "    top_k=5,\n",
+    "    similarity_cutoff=0.1,\n",
     ")\n",
     "\n",
     "print(\"Top Pairs using Cosine Similarity (Weighted):\")\n",
@@ -845,40 +676,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "fa369f63"
-   },
-   "source": [
-    "### Comprehensive Similarity Metric Comparison\n",
-    "\n",
-    "We will now use Neo4j GDS similarity functions to compare users based on their aggregated activity feature vectors. We will calculate:\n",
-    "1. **Jaccard Similarity**: Measures the intersection over union.\n",
-    "2. **Overlap Similarity**: Measures the intersection over the size of the smaller set.\n",
-    "3. **Cosine Similarity**: Measures the cosine of the angle between vectors.\n",
-    "4. **Pearson Similarity**: Measures the linear correlation between vectors."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "b6367241"
-   },
+   "metadata": {},
    "source": [
     "## Section 3: Feature-Based Vector Similarity\n",
     "\n",
-    "Beyond just looking at 'who clicked what', we can compare users based on the **content** of their actions. We aggregate the 4-dimensional feature vectors from each user's actions and compare these profile vectors using Cypher functions."
+    "Beyond just looking at 'who clicked what', we can compare users based on the **content** of their actions. We aggregate the 4-dimensional feature vectors from each user's actions and compare these profile vectors using Cypher functions.\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "6UZ3djKcFuBZ"
-   },
+   "metadata": {},
    "source": [
     "### Feature-Based Similarity: Averaging Features per User\n",
     "\n",
     "We aggregate (average) the 4D feature vectors of all actions performed by a user to create a single representative \"behavioral profile\" vector for that user.\n",
-    "This profile captures their overall interaction pattern across activities."
+    "This profile captures their overall interaction pattern across activities.\n"
    ]
   },
   {
@@ -889,7 +701,7 @@
    "source": [
     "similarity_comp_query = \"\"\"\n",
     "MATCH (u:MoocUser {datasetId: 'act-mooc'})\n",
-    "WHERE u.userId IN [0, 1] // Comparing User 0 and User 1\n",
+    "WHERE u.userId IN [0, 1]\n",
     "MATCH (u)-[:PERFORMED]->(a:MoocAction)\n",
     "WITH u.userId AS userId,\n",
     "     [avg(a.featureVector[0]), avg(a.featureVector[1]), avg(a.featureVector[2]), avg(a.featureVector[3])] AS vector\n",
@@ -908,12 +720,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "3cc8f2b8"
-   },
+   "metadata": {},
    "source": [
     "### Similarity Comparison: User 2 vs User 3\n",
-    "We will now apply the same logic to compare the feature vectors of User 2 and User 3."
+    "\n",
+    "We will now apply the same logic to compare the feature vectors of User 2 and User 3.\n"
    ]
   },
   {
@@ -943,9 +754,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "7b04beb6"
-   },
+   "metadata": {},
    "source": [
     "## Section 4: K-Nearest Neighbors (KNN)\n",
     "\n",
@@ -954,20 +763,16 @@
     "We will:\n",
     "1.  **Aggregate Features**: Average the action features for each user.\n",
     "2.  **Project Node Properties**: Create a graph projection where `MoocUser` nodes have a `featureVector` property.\n",
-    "3.  **Run KNN**: Find the top-K most similar users based on Euclidean distance of those vectors."
+    "3.  **Run KNN**: Find the top-K most similar users based on Euclidean distance of those vectors.\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "0xl0kSE-esyK"
-   },
+   "metadata": {},
    "source": [
     "### 4.1 Prepare User Feature Vectors in the Database\n",
     "\n",
-    "\n",
-    "#### Feature-Based Profile Aggregation:\n",
-    "We calculate the ***average*** across all 4 interaction features for each user's actions.\n",
+    "We calculate the **average** across all 4 interaction features for each user's actions.\n",
     "This condenses a user's multi-action history into a single 4D behavioral profile vector\n",
     "stored on the MoocUser node, enabling property-based similarity algorithms like KNN.\n"
    ]
@@ -979,7 +784,6 @@
    "outputs": [],
    "source": [
     "print(\"Calculating average feature vectors for users...\")\n",
-    "\n",
     "\n",
     "gds.run_cypher(\"\"\"\n",
     "MATCH (u:MoocUser {datasetId: 'act-mooc'})-[:PERFORMED]->(a:MoocAction)\n",
@@ -994,12 +798,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "NV55v5ume483"
-   },
+   "metadata": {},
    "source": [
     "### 4.2 Project Graph with Properties\n",
-    "Remote projection including the node property\n"
+    "\n",
+    "Remote projection including the node property.\n"
    ]
   },
   {
@@ -1008,12 +811,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "knn_graph_name = 'user-features-knn'\n",
+    "knn_graph_name = \"user-features-knn\"\n",
     "\n",
-    "# Single-line graph drop\n",
-    "gds.graph.drop(knn_graph_name, failIfMissing=False)\n",
-    "\n",
-    "# Remote KNN Graph Projection string for AGA setup\n",
     "REMOTE_KNN_PROJECT = \"\"\"\n",
     "MATCH (u:MoocUser {datasetId: $datasetId})\n",
     "RETURN gds.graph.project.remote(\n",
@@ -1026,21 +825,19 @@
     ")\n",
     "\"\"\".strip()\n",
     "\n",
-    "# Execute project remotely via standard gds.graph.project\n",
-    "g_knn, _ = gds.graph.project(\n",
+    "g_knn, _ = gds.graph.project.cypher(\n",
     "    knn_graph_name,\n",
     "    REMOTE_KNN_PROJECT,\n",
-    "    query_parameters={\"datasetId\": \"act-mooc\"}\n",
+    "    query_parameters={\"datasetId\": \"act-mooc\"},\n",
+    "    overwrite=True,\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "AdB2DmP2fFkU"
-   },
+   "metadata": {},
    "source": [
-    "### 4.3 Run KNN Stream\n"
+    "### 4.3 Run KNN Stream"
    ]
   },
   {
@@ -1051,33 +848,25 @@
    "source": [
     "print(\"Running KNN algorithm...\")\n",
     "\n",
-    "# Execute KNN stream and display the top results directly\n",
     "knn_results = gds.knn.stream(\n",
     "    g_knn,\n",
-    "    nodeProperties=['featureVector'],\n",
-    "    topK=3,\n",
-    "    sampleRate=1.0,\n",
-    "    randomSeed=42\n",
+    "    node_properties=[\"featureVector\"],\n",
+    "    top_k=3,\n",
+    "    sample_rate=1.0,\n",
+    "    random_seed=42,\n",
     ")\n",
     "\n",
-    "# Rename columns for clean display\n",
-    "knn_results = knn_results.rename(columns={\n",
-    "    \"node1\": \"user_a\",\n",
-    "    \"node2\": \"user_b\",\n",
-    "    \"similarity\": \"score\"\n",
-    "})\n",
+    "knn_results = knn_results.rename(columns={\"node1\": \"user_a\", \"node2\": \"user_b\", \"similarity\": \"score\"})\n",
     "\n",
     "print(\"Top KNN Similarity results (Feature-based similarity):\")\n",
-    "display(knn_results.sort_values('score', ascending=False).head(10))"
+    "display(knn_results.sort_values(\"score\", ascending=False).head(10))"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "vavFZEP2fTPu"
-   },
+   "metadata": {},
    "source": [
-    "###  Summary of top 5 most similar user pairs from KNN results\n"
+    "### Summary of top 5 most similar user pairs from KNN results\n"
    ]
   },
   {
@@ -1086,7 +875,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "top_5_knn = knn_results.sort_values('score', ascending=False).head(5)\n",
+    "top_5_knn = knn_results.sort_values(\"score\", ascending=False).head(5)\n",
     "\n",
     "print(\"Top 5 Most Similar User Pairs (KNN):\")\n",
     "for index, row in top_5_knn.iterrows():\n",
@@ -1097,28 +886,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "428ee805"
-   },
+   "metadata": {},
    "source": [
     "### Comparing KNN (Behavioral) vs. Jaccard (Structural) Similarity\n",
     "\n",
-    "In this step, we merge the results from the KNN algorithm (which used averaged feature vectors) with the Jaccard similarity results (which used shared activity neighbors). This helps us identify if users who *act* similarly also interact with the *same* activities."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "xp_Nwzndf3kl"
-   },
-   "source": [
-    "Ensure column names are consistent for merging\n",
-    "\n",
-    "jaccard_df has [node1, node2, similarity]\n",
-    "\n",
-    "knn_results has [user_a, user_b, score]\n",
-    "\n",
-    "Rename jaccard_df for a clean merge"
+    "In this step, we merge the results from the KNN algorithm (which used averaged feature vectors) with the Jaccard similarity results (which used shared activity neighbors). This helps us identify if users who *act* similarly also interact with the *same* activities.\n"
    ]
   },
   {
@@ -1127,66 +899,67 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import pandas as pd\n",
-    "\n",
     "# Prepare Jaccard results for comparison\n",
-    "jaccard_compare = jaccard_df.rename(columns={\n",
-    "    'node1': 'user_a',\n",
-    "    'node2': 'user_b',\n",
-    "    'similarity': 'jaccard_score'\n",
-    "})\n",
+    "jaccard_compare = jaccard_df.rename(columns={\"node1\": \"user_a\", \"node2\": \"user_b\", \"similarity\": \"jaccard_score\"})\n",
     "\n",
     "# Convert IDs to integer to ensure matching types across datasets\n",
-    "jaccard_compare['user_a'] = jaccard_compare['user_a'].astype(int)\n",
-    "jaccard_compare['user_b'] = jaccard_compare['user_b'].astype(int)\n",
-    "knn_results['user_a'] = knn_results['user_a'].astype(int)\n",
-    "knn_results['user_b'] = knn_results['user_b'].astype(int)\n",
+    "jaccard_compare[\"user_a\"] = jaccard_compare[\"user_a\"].astype(int)\n",
+    "jaccard_compare[\"user_b\"] = jaccard_compare[\"user_b\"].astype(int)\n",
+    "knn_results[\"user_a\"] = knn_results[\"user_a\"].astype(int)\n",
+    "knn_results[\"user_b\"] = knn_results[\"user_b\"].astype(int)\n",
     "\n",
     "# Inner merge on matching user pairs\n",
-    "comparison_df = pd.merge(\n",
-    "    knn_results,\n",
-    "    jaccard_compare,\n",
-    "    on=['user_a', 'user_b'],\n",
-    "    how='inner'\n",
-    ")\n",
+    "comparison_df = pd.merge(knn_results, jaccard_compare, on=[\"user_a\", \"user_b\"], how=\"inner\")\n",
     "\n",
     "print(f\"Found {len(comparison_df)} pairs that appear in both similarity results.\")\n",
-    "\n",
-    "# Display top overlapping similarity comparisons\n",
-    "if not comparison_df.empty:\n",
-    "    display(comparison_df.sort_values(by=['score', 'jaccard_score'], ascending=False).head(10))\n",
-    "else:\n",
-    "    print(\"No overlapping pairs found between KNN and Jaccard sets at the current thresholds.\")"
+    "display(comparison_df.sort_values(by=[\"score\", \"jaccard_score\"], ascending=False).head(10))"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "d659d9ad"
-   },
+   "metadata": {},
    "source": [
     "## Final Summary: Multi-Faceted Similarity Analysis\n",
     "\n",
     "In this notebook, we successfully built an end-to-end Graph Data Science pipeline using the **SNAP `act-mooc`** dataset and **Neo4j Aura**.\n",
     "\n",
     "### Key Stages Completed:\n",
-    "1. **Data Ingestion**: We managed a high-volume import of 150,000 actions, mapping users and activities into a structured graph schema while respecting Neo4j Aura's free-tier limits.\n",
+    "1. **Data Ingestion**: We managed a high-volume import of 150,000 actions, mapping users and activities into a structured graph schema while respecting the session memory limits.\n",
     "2. **Structural Similarity (Jaccard & Overlap)**: We identified users who interact with the same resources. Our comparison showed that many users share nearly identical activity sets, which is ideal for collaborative filtering recommendations.\n",
     "3. **Feature-Based Similarity (KNN)**: We used behavior-based vectors (averages of action features) to find users who *act* similarly, even if they don't share the same target activities.\n",
-    "4. **Metric Comparison**: We successfully merged structural and behavioral results, finding 116 user pairs that were highly similar in both metrics—proving that behavioral profiles are strong indicators of shared intent in this dataset.\n",
+    "4. **Metric Comparison**: We merged structural and behavioral results, finding user pairs that were highly similar in both metrics—proving that behavioral profiles are strong indicators of shared intent in this dataset.\n",
     "\n",
     "### Which Metric to Use?\n",
     "- **Jaccard**: Best for 'people who bought this also bought that' scenarios.\n",
     "- **Overlap**: Best for detecting 'Expert' vs. 'Novice' users where one user's history is a subset of another's.\n",
-    "- **KNN (Cosine/Euclidean)**: Best for content-based matching based on latent features or interaction style."
+    "- **KNN (Cosine/Euclidean)**: Best for content-based matching based on latent features or interaction style.\n"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "id": "jWz5mgrGMJCT"
+    "tags": [
+     "teardown"
+    ]
    },
-   "source": []
+   "outputs": [],
+   "source": [
+    "gds.delete()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "teardown"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "gds.run_cypher(\"MATCH (n) DETACH DELETE n\")"
+   ]
   }
  ],
  "metadata": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ notebook-base = [
 ]
 notebook-aura-ci = [
     { include-group = "notebook-base" },
+    "matplotlib",
     "python-dotenv",
     "pyspark[sql]"
 ]

--- a/scripts/run_notebooks.py
+++ b/scripts/run_notebooks.py
@@ -27,7 +27,7 @@ ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
 VERSION_CELL_TAG = "verify-version"
 TEARDOWN_CELL_TAG = "teardown"
 
-SESSION_NOTEBOOKS = ["graph-analytics-serverless.ipynb"]
+SESSION_NOTEBOOKS = ["graph-analytics-serverless.ipynb", "similarity_algorithms.ipynb"]
 SESSION_SELF_MANAGED_NOTEBOOKS = [
     "graph-analytics-serverless-self-managed.ipynb",
     "graph-analytics-serverless-standalone.ipynb",


### PR DESCRIPTION
Follow-up to #1225. Migrates the similarity notebook to the 2.0 API (snake_case), makes it CI-compatible, and applies remaining review feedback.

## Changes

### 2.0 API migration
- `nodeSimilarity` → `node_similarity`
- `graph.project(name, cypher)` → `graph.project.cypher(name, cypher)`
- `graph.relationshipProperties.write` → `graph.relationships.write`
- `failIfMissing` → `fail_if_missing`
- All kwargs: `topK` → `top_k`, `similarityCutoff` → `similarity_cutoff`, etc.
- Result dict keys: `nodesCompared` → `nodes_compared`, etc.

### CI compatibility
- Credentials from `os.environ` + `load_dotenv` (matching `graph-analytics-serverless.ipynb`)
- `%pip install` with `verify-version` tag
- `aura` tag on title cell
- `teardown` tags on cleanup cells
- Added to `SESSION_NOTEBOOKS` in `run_notebooks.py`
- Fixed `/content/` Colab path to relative path
- Removed Colab `id` cell metadata (for `clean_notebooks.py` compliance)
- Replaced shell magic `!mkdir`/`!tar`/`!ls` with `tarfile`/`os` module

### Review fixes
- Fixed markdown referencing `my_session` → `gds`
- Removed `if df.empty:` checks — display directly
- Fixed first graph drop to use `fail_if_missing=False`
- Fixed `Constants` → `Constraints` typo
- Fixed step numbering consistency
- Removed `try/except` around write call
- Consolidated redundant EDA cells (3 → 2)

### Verification
All checks pass: `ruff check`, `ruff format`, `mypy`, `clean_notebooks`