### PR TITLE
Assert GDL graph configuration contents

### DIFF
--- a/justfile
+++ b/justfile
@@ -141,6 +141,7 @@ update-aga-images:
 
     images=(
         "${GDS_SESSION_IMAGE:-europe-west1-docker.pkg.dev/gds-aura-artefacts/gds/gds-session:aura-release}"
+        "europe-west1-docker.pkg.dev/gds-aura-artefacts/gds/gds-session:latest"
         "europe-west1-docker.pkg.dev/gds-aura-artefacts/gds/mock-runtime-api:latest"
         "europe-west1-docker.pkg.dev/gds-aura-artefacts/gds/python-runtime:latest"
         "europe-west1-docker.pkg.dev/gds-aura-artefacts/gds/mock-gds-api:latest"

--- a/tests/integration/procedure_surface/arrow/catalog/test_graph_api_arrow.py
+++ b/tests/integration/procedure_surface/arrow/catalog/test_graph_api_arrow.py
@@ -1,44 +1,58 @@
 from typing import Generator
 
 import pytest
+from pandas import DataFrame
 
 from graphdatascience.arrow_client.authenticated_flight_client import AuthenticatedArrowClient
 from graphdatascience.graph.graph_api import Graph
-from tests.integration.procedure_surface.arrow.graph_creation_helper import create_graph
+from graphdatascience.procedure_surface.arrow.catalog import CatalogArrowEndpoints
 
 
 @pytest.fixture
 def G(arrow_client: AuthenticatedArrowClient) -> Generator[Graph, None, None]:
-    gdl = """
-        CREATE
-        (a: Node {x: 1}),
-        (b: Node {x: 2}),
-        (c: Node {x: 3}),
-        (d: Node2 {s: 4}),
-        (a)-[:REL {y: 42.0}]->(b),
-        (a)-[:REL {y: 13.37}]->(c),
-        (b)-[:REL {z: 7.9}]->(c),
-        (b)-[:REL2 {q: 7.9}]->(d)
-        """
+    nodes = DataFrame(
+        {
+            "nodeId": [0, 1],
+            "labels": [["A"], ["B"]],
+            "propA": [1337, 42.1],
+        }
+    )
+    relationships = DataFrame(
+        {
+            "sourceNodeId": [0, 1],
+            "targetNodeId": [1, 0],
+            "relationshipType": ["REL", "REL2"],
+            "relPropA": [1337.2, 42],
+        }
+    )
 
-    with create_graph(arrow_client, "g", gdl) as G:
-        yield G
+    endpoints = CatalogArrowEndpoints(arrow_client)
+    G = endpoints.construct(
+        graph_name="g",
+        nodes=nodes,
+        relationships=relationships,
+    )
+    yield G
+
+    G.drop(fail_if_missing=False)
 
 
 def test_graph_configuration(G: Graph) -> None:
-    assert G.configuration() == {}  # GDL based graph has an empty config
+    configuration = G.configuration()
+
+    assert "readConcurrency" in configuration.keys()
 
 
 def test_graph_node_count(G: Graph) -> None:
-    assert G.node_count() == 4
+    assert G.node_count() == 2
 
 
 def test_graph_relationship_count(G: Graph) -> None:
-    assert G.relationship_count() == 4
+    assert G.relationship_count() == 2
 
 
 def test_graph_node_labels(G: Graph) -> None:
-    assert set(G.node_labels()) == {"Node", "Node2"}
+    assert set(G.node_labels()) == {"A", "B"}
 
 
 def test_graph_relationship_types(G: Graph) -> None:
@@ -47,23 +61,23 @@ def test_graph_relationship_types(G: Graph) -> None:
 
 def test_graph_node_properties(G: Graph) -> None:
     node_properties = G.node_properties()
-    assert node_properties == {"Node": ["x"], "Node2": ["s"]}
+    assert node_properties == {"A": ["propA"], "B": ["propA"]}
 
 
 def test_graph_relationship_properties(G: Graph) -> None:
     rel_properties = G.relationship_properties()
     assert isinstance(rel_properties, dict)
     assert rel_properties.keys() == {"REL", "REL2"}
-    assert set(rel_properties["REL"]) == {"y", "z"}
-    assert rel_properties["REL2"] == ["q"]
+    assert set(rel_properties["REL"]) == {"relPropA"}
+    assert rel_properties["REL2"] == ["relPropA"]
 
 
 def test_graph_degree_distribution(G: Graph) -> None:
-    assert G.degree_distribution()["mean"] == 1.75
+    assert G.degree_distribution()["mean"] == 1.0
 
 
 def test_graph_density(G: Graph) -> None:
-    assert G.density() == pytest.approx(0.333, 0.01)
+    assert G.density() == 1.0
 
 
 def test_graph_memory_usage(G: Graph) -> None:
@@ -110,7 +124,7 @@ def test_graph_modification_time(G: Graph) -> None:
 
 
 def test_graph_str(G: Graph) -> None:
-    assert str(G) == "Graph(name=g, node_count=4, relationship_count=4)"
+    assert str(G) == "Graph(name=g, node_count=2, relationship_count=2)"
 
 
 def test_graph_repr(G: Graph) -> None:


### PR DESCRIPTION
The GDL-based graph configuration is no longer empty; it exposes the
creation config minus the nodeCount/relationshipCount estimation
sentinels. We assert loosely on the defining gdlGraph field only, as
the config surface is still evolving.
